### PR TITLE
Add native API `OpenSpecifiedPluginFodler`

### DIFF
--- a/core/src/renderer/renderer.cc
+++ b/core/src/renderer/renderer.cc
@@ -78,6 +78,19 @@ static V8Value *native_OpenPluginsFolder(const vec<V8Value *> &args)
     return nullptr;
 }
 
+static V8Value* native_OpenSpecifiedPluginFodler(const vec<V8Value*>& args)
+{
+    wstr path = config::pluginsDir();
+    for (V8Value* arg : args) {
+        path = path + L"\\" + arg->asString()->str;
+    }
+    if (utils::isDir(path)) {
+        utils::openLink(path);
+        return V8Value::boolean(true);
+    }
+    return V8Value::boolean(false);
+}
+
 static V8Value *native_ReloadClient(const vec<V8Value *> &args)
 {
     auto context = cef_v8context_get_current_context();
@@ -95,6 +108,7 @@ static map<wstr, V8FunctionHandler> m_nativeDelegateMap
     { L"OpenDevTools", native_OpenDevTools },
     { L"OpenAssetsFolder", native_OpenAssetsFolder },
     { L"OpenPluginsFolder", native_OpenPluginsFolder },
+    { L"OpenSpecifiedPluginFodler", native_OpenSpecifiedPluginFodler },
     { L"ReloadClient", native_ReloadClient },
 
     { L"LoadDataStore", native_LoadDataStore },

--- a/plugins/src/preload/api/index.ts
+++ b/plugins/src/preload/api/index.ts
@@ -16,6 +16,17 @@ window.openPluginsFolder = function () {
   native.OpenPluginsFolder();
 };
 
+window.openSpecifiedPluginFodler = function (pluginName:string, relativePath:string) {
+  if(arguments.length != 2) return false;
+  if(typeof pluginName !== "string" || typeof relativePath !== "string") return false;
+
+  if(pluginName.includes("..") || relativePath.includes("..")) return false;
+  if(pluginName==="") pluginName = "."
+  if(relativePath==="") relativePath = "."
+
+  return native.OpenSpecifiedPluginFodler(pluginName,relativePath);
+}
+
 window.reloadClient = function () {
   native.ReloadClient();
 };

--- a/plugins/src/preload/api/native.ts
+++ b/plugins/src/preload/api/native.ts
@@ -2,6 +2,7 @@ interface Native {
   OpenDevTools: (remote: boolean) => void;
   OpenAssetsFolder: () => void;
   OpenPluginsFolder: () => void;
+  OpenSpecifiedPluginFodler: (pluginName:string, relativePath:string)=> boolean;
   ReloadClient: () => void;
 
   GetWindowEffect: () => string;

--- a/plugins/src/types.d.ts
+++ b/plugins/src/types.d.ts
@@ -48,6 +48,7 @@ declare const Effect: Effect;
 declare const openDevTools: (remote?: boolean) => void;
 declare const openAssetsFolder: () => void;
 declare const openPluginsFolder: () => void;
+declare const openSpecifiedPluginFodler: (pluginName:string, relativePath:string) => boolean;
 declare const reloadClient: () => void;
 declare const restartClient: () => void;
 declare const getScriptPath: () => string | undefined;
@@ -62,6 +63,7 @@ declare interface Window {
   openDevTools: typeof openDevTools;
   openAssetsFolder: typeof openAssetsFolder;
   openPluginsFolder: typeof openPluginsFolder;
+  openSpecifiedPluginFodler: typeof openSpecifiedPluginFodler;
   reloadClient: typeof reloadClient;
   restartClient: typeof restartClient;
   getScriptPath: typeof getScriptPath;


### PR DESCRIPTION
What's new:
```typescript
// New native API
OpenSpecifiedPluginFodler: (pluginName:string, relativePath:string)=> boolean;

// user-level exposure
window.openSpecifiedPluginFodler
```

Usage:
```Javascript
// pass into 2 args correctly or get a `false`
window.openSpecifiedPluginFodler("Myplugin/assets")
>>false
window.openSpecifiedPluginFodler("MyPlugin","assets","whatever")
>>false

window.openSpecifiedPluginFodler("MyPlugin","assets")
window.openSpecifiedPluginFodler("MyPlugin","assets/music")
window.openSpecifiedPluginFodler("MyPlugin","assets\\images")

// if arg is "" then it will be converted to "."
// equivalent to openPluginsFolder()
window.openSpecifiedPluginFodler("","")

// `".." is not allowed
window.openSpecifiedPluginFodler("../..","..")
>>false

```