### PR TITLE
Add optional `path` param to `OpenPluginsFolder`

### DIFF
--- a/core/src/renderer/renderer.cc
+++ b/core/src/renderer/renderer.cc
@@ -72,10 +72,17 @@ static V8Value *native_OpenAssetsFolder(const vec<V8Value *> &args)
 }
 
 static V8Value *native_OpenPluginsFolder(const vec<V8Value *> &args)
-{
-    utils::openLink(config::pluginsDir());
+{   
+    wstr destPath = config::pluginsDir();
+    if (args.size()) {
+        destPath = destPath + L"\\" + args[0]->asString()->str;
+        if (!utils::isDir(destPath)) {
+            return V8Value::boolean(false);
+        }
+    }
+    utils::openLink(destPath);
 
-    return nullptr;
+    return V8Value::boolean(true);
 }
 
 static V8Value *native_ReloadClient(const vec<V8Value *> &args)

--- a/plugins/src/preload/api/index.ts
+++ b/plugins/src/preload/api/index.ts
@@ -12,8 +12,15 @@ window.openAssetsFolder = function () {
   native.OpenAssetsFolder();
 };
 
-window.openPluginsFolder = function () {
-  native.OpenPluginsFolder();
+window.openPluginsFolder = function (path?: string) {
+  if(arguments.length > 1) return false;
+  if (path === undefined) return native.OpenPluginsFolder();
+  if(typeof path !== 'string') return false;
+
+  if(path.includes('..')) return false;
+  if(path === "") path = ".";
+
+  return native.OpenPluginsFolder(path);
 };
 
 window.reloadClient = function () {

--- a/plugins/src/preload/api/native.ts
+++ b/plugins/src/preload/api/native.ts
@@ -1,7 +1,7 @@
 interface Native {
   OpenDevTools: (remote: boolean) => void;
   OpenAssetsFolder: () => void;
-  OpenPluginsFolder: () => void;
+  OpenPluginsFolder: (path?: string) => boolean;
   ReloadClient: () => void;
 
   GetWindowEffect: () => string;

--- a/plugins/src/types.d.ts
+++ b/plugins/src/types.d.ts
@@ -47,7 +47,7 @@ declare const Effect: Effect;
 
 declare const openDevTools: (remote?: boolean) => void;
 declare const openAssetsFolder: () => void;
-declare const openPluginsFolder: () => void;
+declare const openPluginsFolder: (path?: string) => boolean;
 declare const reloadClient: () => void;
 declare const restartClient: () => void;
 declare const getScriptPath: () => string | undefined;


### PR DESCRIPTION
closes #67 

What's new:
```TypeScript
// a new param to specify subfolder path of Plugins root dir
OpenPluginsFolder: (path?: string) => boolean;
// user-level api
window.openPluginsFolder
```

Usage:
```javascript
openPluginsFolder()
>true
// "" is converted into "."
openPluginsFolder("")
>true
openPluginsFolder(".")
>true
openPluginsFolder("mypg\\folder1/folder2")
>true
openPluginsFolder("mypg\\文件夹\\文件夹2")
>true
openPluginsFolder("mypg/文件夹/文件夹2")
>true
openPluginsFolder("..")
>false
openPluginsFolder("mypg","argc>1","return false")
>false
openPluginsFolder([])
>false
```