### PR TITLE
[Core] Add `context.fs` & remove `window.PluginFS`

### DIFF
--- a/plugins/src/preload/api/PluginFS.ts
+++ b/plugins/src/preload/api/PluginFS.ts
@@ -1,6 +1,6 @@
 import { native } from './native';
 
-window.PluginFS = {
+const globalFs = {
   read(path: string) {
     return new Promise<string | undefined>((resolve) => {
       const pluginName = getScriptPath()?.match(/\/([^/]+)\/index\.js$/)?.[1]
@@ -47,6 +47,7 @@ window.PluginFS = {
     });
   }
 }
+window.Pengu.fs = Object.freeze(globalFs)
 
 function pathCheck(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
   const originalMethod = descriptor.value;

--- a/plugins/src/preload/api/PluginFS.ts
+++ b/plugins/src/preload/api/PluginFS.ts
@@ -47,3 +47,74 @@ window.PluginFS = {
     });
   }
 }
+
+function pathCheck(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+  const originalMethod = descriptor.value;
+  descriptor.value = function (...args: any[]) {
+    const [path, ...rest] = args;
+    const doubleDotSlash = /\.\.\//;
+    if (doubleDotSlash.test(path)) {
+      console.error('%c Pengu ', 'background: #183461; color: #fff', "PluginFS path check failed.");
+      return Promise.resolve(undefined);
+    }
+    return originalMethod.apply(this, [path, ...rest]);
+  }
+  return descriptor;
+}
+
+export class FS {
+  constructor(private pluginName: string) {
+    this.pluginName = pluginName;
+  }
+
+  @pathCheck
+  read(path: string) {
+    return new Promise<string | undefined>((resolve) => {
+      const result = native.ReadFile(this.pluginName + '/' + path);
+      resolve(result);
+    });
+  }
+
+  @pathCheck
+  write(path: string, content: string, enableAppendMode: boolean = false) {
+    return new Promise<boolean>((resolve) => {
+      const result = native.WriteFile(this.pluginName + '/' + path, content, enableAppendMode);
+      if (!result) {
+        console.warn(`PluginFS.write failed on ${path}.`);
+      }
+      resolve(result);
+    });
+  }
+
+  @pathCheck
+  mkdir(path: string) {
+    return new Promise<boolean>((resolve) => {
+      const result = native.MkDir(this.pluginName!, path);
+      resolve(result);
+    });
+  }
+
+  @pathCheck
+  stat(path: string) {
+    return new Promise<FileStat | undefined>((resolve) => {
+      const result = native.Stat(this.pluginName + '/' + path);
+      resolve(result);
+    });
+  }
+
+  @pathCheck
+  ls(path: string) {
+    return new Promise<string[] | undefined>((resolve) => {
+      const result = native.Ls(this.pluginName + '/' + path);
+      resolve(result);
+    });
+  }
+
+  @pathCheck
+  rm(path: string, recursively: boolean = false) {
+    return new Promise<number>((resolve) => {
+      const result = native.Remove(this.pluginName + '/' + path, recursively);
+      resolve(result);
+    });
+  }
+}

--- a/plugins/src/preload/loader.ts
+++ b/plugins/src/preload/loader.ts
@@ -1,4 +1,5 @@
 import { rcp, socket } from './rcp';
+import { FS } from './api/PluginFS';
 
 async function loadPlugin(entry: string) {
   let stage = 'load';
@@ -10,7 +11,13 @@ async function loadPlugin(entry: string) {
     // Init immediately
     if (typeof plugin.init === 'function') {
       stage = 'initialize';
-      await plugin.init({ rcp, socket });
+      const pluginName = entry.substring(0, entry.indexOf('/'));
+      const initContext = { rcp, socket};
+      // If it's not top-level JS
+      if (pluginName) {
+        initContext['fs'] = new FS(pluginName);
+      }
+      await plugin.init(initContext);
     }
 
     // Register load

--- a/plugins/src/types.d.ts
+++ b/plugins/src/types.d.ts
@@ -73,17 +73,18 @@ interface PluginFS {
 
 // globals
 
-namespace Pengu {
-  const version: string;
-  const superPotato: boolean;
-  const plugins: string[];
+interface Pengu {
+  version: string
+  superPotato: boolean
+  plugins: string[]
+  fs: PluginFS
 }
 
 declare const DataStore: DataStore;
 declare const CommandBar: CommandBar;
 declare const Toast: Toast;
 declare const Effect: Effect;
-declare const PluginFS: PluginFS;
+declare const Pengu: Pengu;
 
 declare const openDevTools: (remote?: boolean) => void;
 declare const openAssetsFolder: () => void;
@@ -99,7 +100,8 @@ declare interface Window {
   CommandBar: CommandBar;
   Toast: Toast;
   Effect: Effect;
-  PluginFS: PluginFS;
+  Pengu: Pengu;
+  
 
   openDevTools: typeof openDevTools;
   openAssetsFolder: typeof openAssetsFolder;

--- a/plugins/tsconfig.json
+++ b/plugins/tsconfig.json
@@ -9,6 +9,7 @@
       "DOM.Iterable"
     ],
     "skipLibCheck": true,
+    "experimentalDecorators": true,
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
[#71 ](https://github.com/PenguLoader/PenguLoader/issues/71#issuecomment-1811767920)

`window.PluginFS` is now moved to `window.Pengu.fs`.

`window.Pengu.fs` is now undocumented should be used for debugging purposes only.

