### PR TITLE
a bug due to null value

### DIFF
--- a/loader/Main/Module.cs
+++ b/loader/Main/Module.cs
@@ -23,8 +23,17 @@ namespace PenguLoader.Main
                 //throw new UnauthorizedAccessException();
 
                 var old = IFEO.GetDebugger(TargetName);
-                IFEO.RemoveDebugger(TargetName);
-                IFEO.SetDebugger(TargetName, old);
+                if (old != null)
+                {
+                    IFEO.RemoveDebugger(TargetName);
+                    IFEO.SetDebugger(TargetName, old);
+                }
+                else if (Symlink.IsSymbolic(SymlinkPath)) 
+                {
+                    //if  can create  "LeagueClientUx.exe" but not "Debugger" because of UnauthorizedAccessException
+                    //already use SymlinkMode
+                    SymlinkMode = true;
+                }
             }
             catch (UnauthorizedAccessException)
             {

--- a/loader/Main/Symlink.cs
+++ b/loader/Main/Symlink.cs
@@ -36,7 +36,11 @@ namespace PenguLoader.Main
         {
             return CreateSymbolicLinkW(linkPath, sourcePath);
         }
-
+        public static bool IsSymbolic(string path)
+        {
+            FileInfo pathInfo = new FileInfo(path);
+            return pathInfo.Attributes.HasFlag(FileAttributes.ReparsePoint);
+        }
         public static string Resolve(string path)
         {
             if (!File.Exists(path))


### PR DESCRIPTION

i use it success but when i reopen "LeagueClientUx.exe", `active_status` display `off`(but it work).
when i change the `active_status` , it report a bug like follow
![bug](https://github.com/PenguLoader/PenguLoader/assets/23274350/7c3b1d07-f6e4-4d19-bebe-5c2a5ee72f0f)

**************************************************************                                            
i find the reason:

in `\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\LeagueClientUx.exe`
if  can create  "LeagueClientUx.exe" but not "Debugger" because of UnauthorizedAccessException
it will be use SymlinkMode success
but if i reopen `Pengu Loader.exe`, `active_status` will show `off`, 
if i want not use Pengu Loader, i can't change it to off

**************************************************************

so I added a non-empty critique
if dont add `old != null`, code will run here:
```

            catch
            {
                // if dont add `old != null`, code will run here and  caused a bug
                // TODO: handle some other errors
            }
``` 