### PR TITLE
alternative preload

### DIFF
--- a/core/core.vcxproj
+++ b/core/core.vcxproj
@@ -22,6 +22,8 @@
     <ClCompile Include="src\browser\assets.cc" />
     <ClCompile Include="src\browser\browser.cc" />
     <ClCompile Include="src\browser\devtools.cc" />
+    <ClCompile Include="src\browser\filter.cpp" />
+    <ClCompile Include="src\browser\filters\indexPageFilter.cpp" />
     <ClCompile Include="src\browser\keyboard.cc" />
     <ClCompile Include="src\browser\riotclient.cc" />
     <ClCompile Include="src\config.cc" />
@@ -42,6 +44,8 @@
     <None Include="res\module.def" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\browser\filter.h" />
+    <ClInclude Include="src\browser\filters\indexPageFilter.h" />
     <ClInclude Include="src\commons.h" />
     <ClInclude Include="src\hook.h" />
   </ItemGroup>

--- a/core/core.vcxproj.filters
+++ b/core/core.vcxproj.filters
@@ -17,6 +17,9 @@
     <Filter Include="src\utils">
       <UniqueIdentifier>{e0b1c27d-cfeb-41e1-87e3-5f64c8ddc7fd}</UniqueIdentifier>
     </Filter>
+    <Filter Include="src\browser\filters">
+      <UniqueIdentifier>{1e91eb2a-6a2d-4cdd-8e58-9c00d8cc8068}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\dllmain.cc">
@@ -73,6 +76,12 @@
     <ClCompile Include="src\utils\dialog.cc">
       <Filter>src\utils</Filter>
     </ClCompile>
+    <ClCompile Include="src\browser\filter.cpp">
+      <Filter>src\browser</Filter>
+    </ClCompile>
+    <ClCompile Include="src\browser\filters\indexPageFilter.cpp">
+      <Filter>src\browser\filters</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="res\module.def">
@@ -90,6 +99,12 @@
     </ClInclude>
     <ClInclude Include="src\hook.h">
       <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\browser\filter.h">
+      <Filter>src\browser</Filter>
+    </ClInclude>
+    <ClInclude Include="src\browser\filters\indexPageFilter.h">
+      <Filter>src\browser\filters</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/core/src/browser/browser.cc
+++ b/core/src/browser/browser.cc
@@ -4,6 +4,8 @@
 #include "include/capi/cef_client_capi.h"
 #include "include/capi/cef_browser_capi.h"
 
+#include "filter.h"
+
 // BROWSER PROCESS ONLY.
 
 HWND rclient_;
@@ -68,6 +70,8 @@ static void HookMainBrowserClient(cef_client_t *client)
 {
     void HookKeyboardHandler(cef_client_t *client);
     HookKeyboardHandler(client);
+
+    HookRequestHandler(client);
 
     // Hook LifeSpanHandler.
     static auto GetLifeSpanHandler = client->get_life_span_handler;

--- a/core/src/browser/filter.cpp
+++ b/core/src/browser/filter.cpp
@@ -1,0 +1,153 @@
+#include "filter.h"
+
+#include "include/capi/cef_app_capi.h"
+#include "include/capi/cef_client_capi.h"
+#include "include/capi/cef_browser_capi.h"
+#include "include/capi/cef_parser_capi.h"
+#include "include/capi/cef_response_filter_capi.h"
+
+#include "filters/indexPageFilter.h"
+
+#include <map>
+
+struct __RequestHandlersItem {
+    struct _cef_request_handler_t* (CEF_CALLBACK* getHandler)(
+        struct _cef_client_t* self);
+
+    int(CEF_CALLBACK* release)(struct _cef_base_ref_counted_t* self);
+};
+
+struct __ResourceRequestHandlersItem {
+    struct _cef_resource_request_handler_t* (CEF_CALLBACK* getHandler)(
+        struct _cef_request_handler_t* self,
+        struct _cef_browser_t* browser,
+        struct _cef_frame_t* frame,
+        struct _cef_request_t* request,
+        int is_navigation,
+        int is_download,
+        const cef_string_t* request_initiator,
+        int* disable_default_handling);
+
+    int(CEF_CALLBACK* release)(struct _cef_base_ref_counted_t* self);
+};
+
+struct __ResourceResponseFiltersItem {
+    struct _cef_response_filter_t* (CEF_CALLBACK* getHandler)(
+        struct _cef_resource_request_handler_t* self,
+        struct _cef_browser_t* browser,
+        struct _cef_frame_t* frame,
+        struct _cef_request_t* request,
+        struct _cef_response_t* response);
+
+    int(CEF_CALLBACK* release)(struct _cef_base_ref_counted_t* self);
+};
+
+struct __FiltersItem {
+    cef_response_filter_status_t(CEF_CALLBACK* filter)(
+        struct _cef_response_filter_t* self,
+        void* data_in,
+        size_t data_in_size,
+        size_t* data_in_read,
+        void* data_out,
+        size_t data_out_size,
+        size_t* data_out_written);
+
+    int(CEF_CALLBACK* release)(struct _cef_base_ref_counted_t* self);
+};
+
+static std::map<void*, __FiltersItem> __Filters;
+
+static std::map<void*, __RequestHandlersItem> __RequestHandlers;
+static std::map<void*, __ResourceRequestHandlersItem> __ResourceRequestHandlers;
+static std::map<void*, __ResourceResponseFiltersItem> __ResourceResponseFilters;
+
+int(CEF_CALLBACK releaseRequestHandler)(struct _cef_base_ref_counted_t* self) {
+    auto [_, release] = __RequestHandlers[self];
+    auto const result = release(self);
+    if (result) __RequestHandlers.erase(self);
+    return result;
+};
+
+int(CEF_CALLBACK releaseResourceRequestHandler)(struct _cef_base_ref_counted_t* self) {
+    auto [_, release] = __ResourceRequestHandlers[self];
+    auto const result = release(self);
+    if (result) __ResourceRequestHandlers.erase(self);
+    return result;
+};
+
+int(CEF_CALLBACK releaseResourceResponseFilter)(struct _cef_base_ref_counted_t* self) {
+    auto [_, release] = __ResourceResponseFilters[self];
+    auto const result = release(self);
+    if (result) __ResourceResponseFilters.erase(self);
+    return result;
+};
+
+struct _cef_response_filter_t* (CEF_CALLBACK get_resource_response_filter)(
+    struct _cef_resource_request_handler_t* self,
+    struct _cef_browser_t* browser,
+    struct _cef_frame_t* frame,
+    struct _cef_request_t* request,
+    struct _cef_response_t* response) {
+
+
+    auto _url = request->get_url(request);
+    cef_urlparts_t parts{};
+    cef_parse_url(_url, &parts);
+    cef_string_userfree_free(_url);
+
+    std::wstring host(parts.host.str, parts.host.length);
+    std::wstring path(parts.path.str, parts.path.length);
+
+    auto [getHandler, _] = __ResourceResponseFilters[self];
+    auto handler = getHandler(self, browser, frame, request, response);
+
+    if (!host.compare(L"127.0.0.1") && !path.compare(L"/index.html")) {
+        //index page
+        if (handler == nullptr) {
+            auto filter = new indexPageFilter();
+            filter->base.base.add_ref((cef_base_ref_counted_t*)(filter));
+
+            return (cef_response_filter_t*)filter;
+        } else {
+            //TODO: add proxy filter
+        }
+    }
+
+    return handler;
+};
+
+struct _cef_resource_request_handler_t* (CEF_CALLBACK get_resource_request_handler)(
+    struct _cef_request_handler_t* self,
+    struct _cef_browser_t* browser,
+    struct _cef_frame_t* frame,
+    struct _cef_request_t* request,
+    int is_navigation,
+    int is_download,
+    const cef_string_t* request_initiator,
+    int* disable_default_handling) {
+    auto [getHandler, _] = __ResourceRequestHandlers[self];
+    auto handler = getHandler(self, browser, frame, request, is_download, is_download, request_initiator, disable_default_handling);
+
+    __ResourceResponseFilters[handler] = { handler->get_resource_response_filter, handler->base.release };
+    handler->base.release = releaseResourceResponseFilter;
+    handler->get_resource_response_filter = get_resource_response_filter;
+
+    return handler;
+};
+
+struct _cef_request_handler_t* (CEF_CALLBACK get_request_handler)(struct _cef_client_t* self) {
+    auto [getHandler, _] = __RequestHandlers[self];
+    auto handler = getHandler(self);
+
+    __ResourceRequestHandlers[handler] = { handler->get_resource_request_handler, handler->base.release };
+    handler->base.release = releaseResourceRequestHandler;
+    handler->get_resource_request_handler = get_resource_request_handler;
+
+    return handler;
+};
+
+void HookRequestHandler(cef_client_t* client) {
+    __RequestHandlers[client] = { client->get_request_handler, client->base.release };
+    client->base.release = releaseRequestHandler;
+    client->get_request_handler = get_request_handler;
+}

--- a/core/src/browser/filter.h
+++ b/core/src/browser/filter.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "include/capi/cef_client_capi.h"
+
+void HookRequestHandler(cef_client_t* client);

--- a/core/src/browser/filters/indexPageFilter.cpp
+++ b/core/src/browser/filters/indexPageFilter.cpp
@@ -1,0 +1,80 @@
+#include "indexPageFilter.h"
+
+void(CEF_CALLBACK add_ref)(struct indexPageFilter* self) {
+    self->count += 1;
+};
+
+int(CEF_CALLBACK release)(struct indexPageFilter* self) {
+    if (--(self->count) != 0) return false;
+    delete self;
+    return true;
+};
+
+int(CEF_CALLBACK has_one_ref)(struct indexPageFilter* self) {
+    return self->count == 1;
+}
+
+int(CEF_CALLBACK has_at_least_one_ref)(struct indexPageFilter* self) {
+    return self->count > 0;
+};
+
+int(CEF_CALLBACK init_filter)(struct indexPageFilter* self) {
+    return true;
+};
+
+cef_response_filter_status_t(CEF_CALLBACK filter)(
+    struct response_filter* self,
+    void* data_in,
+    size_t data_in_size,
+    size_t* data_in_read,
+    void* data_out,
+    size_t data_out_size,
+    size_t* data_out_written) {
+
+    size_t pos = std::string::npos;
+    {
+        const char* data_in_ptr = static_cast<char*>(data_in);
+        std::string src(data_in_ptr, data_in_size);
+        const size_t sp = src.find("<script");
+        const size_t hp = src.find("</head");
+
+        if (sp != std::string::npos && hp != std::string::npos) {
+            pos = sp > hp ? hp : sp;
+        } else if (sp != std::string::npos) {
+            pos = sp;
+        } else if (hp != std::string::npos) {
+            pos = hp;
+        }
+    }
+
+    if (pos != std::string::npos) {
+        memcpy(data_out, data_in, pos);
+        std::string fragment = "<script>debugger;</script>";
+        memcpy(static_cast<char*>(data_out) + pos, fragment.c_str(), fragment.length());
+        memcpy(static_cast<char*>(data_out) + pos + fragment.length(), static_cast<char*>(data_in) + pos, data_in_size - pos);
+        *data_out_written = fragment.length() + data_in_size;
+
+        *data_in_read = data_in_size;
+    } else {
+        *data_out_written = data_in_size < data_out_size ? data_in_size : data_out_size;
+        if (*data_out_written > 0) {
+            memcpy(data_out, data_in, *data_out_written);
+            *data_in_read = *data_out_written;
+        }
+    }
+
+    return RESPONSE_FILTER_DONE;
+};
+
+indexPageFilter::indexPageFilter() {
+    this->base.base.size = sizeof(indexPageFilter);
+    this->base.base.add_ref = decltype(this->base.base.add_ref)(&add_ref);
+    this->base.base.release = decltype(this->base.base.release)(&release);
+    this->base.base.has_one_ref = decltype(this->base.base.has_one_ref)(&has_one_ref);
+    this->base.base.has_at_least_one_ref = decltype(this->base.base.has_at_least_one_ref)(&has_at_least_one_ref);
+
+    this->base.init_filter = decltype(this->base.init_filter)(&init_filter);
+    this->base.filter = decltype(this->base.filter)(&filter);
+
+    this->count = 0;
+}

--- a/core/src/browser/filters/indexPageFilter.h
+++ b/core/src/browser/filters/indexPageFilter.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "include/capi/cef_response_filter_capi.h"
+
+typedef struct indexPageFilter {
+    cef_response_filter_t base;
+    int count;
+
+    indexPageFilter();
+};


### PR DESCRIPTION
> status: WIP

Currently preloading starts too early, no document exists yet, and using `DOMContentLoaded` to delay execution of preload script also dont gonna work, cuz when event get fiered its too late, general script execution already `done`/`pending`.
The perfect moment ot execute preload script is at [`document_start`](https://developer.chrome.com/docs/extensions/reference/api/extensionTypes#type-RunAt), so injecting script tag directly into the page (just before main scripts) is not the worst idea

this change could allow me to start working on node modules compatibility