### PR TITLE
Reintroduce scoped PluginFS

### DIFF
--- a/core/core.vcxproj
+++ b/core/core.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="src\dllmain.cc" />
     <ClCompile Include="src\renderer\v8_datastore.cc" />
     <ClCompile Include="src\renderer\v8_helper.cc" />
+    <ClCompile Include="src\renderer\v8_pluginfs.cc" />
     <ClCompile Include="src\renderer\renderer.cc" />
     <ClCompile Include="src\utils\cefstr.cc" />
     <ClCompile Include="src\utils\dylib.cc" />

--- a/core/core.vcxproj.filters
+++ b/core/core.vcxproj.filters
@@ -55,6 +55,9 @@
     <ClCompile Include="src\renderer\v8_helper.cc">
       <Filter>src\renderer</Filter>
     </ClCompile>
+    <ClCompile Include="src\renderer\v8_pluginfs.cc">
+      <Filter>src\renderer</Filter>
+    </ClCompile>
     <ClCompile Include="src\utils\cefstr.cc">
       <Filter>src\utils</Filter>
     </ClCompile>

--- a/core/src/renderer/renderer.cc
+++ b/core/src/renderer/renderer.cc
@@ -11,6 +11,7 @@ static bool is_main_ = false;
 
 extern V8HandlerFunctionEntry v8_DataStoreEntries[];
 extern V8HandlerFunctionEntry v8_HelperEntries[];
+extern V8HandlerFunctionEntry v8_PluginFSEntries[];
 
 static std::vector<path> get_plugin_entries()
 {
@@ -126,6 +127,7 @@ static void ExposeNativeFunctions(V8Object *window)
     auto list = {
         v8_DataStoreEntries,
         v8_HelperEntries,
+        v8_PluginFSEntries,
     };
 
     for (auto &entries : list) {

--- a/core/src/renderer/v8_datastore.cc
+++ b/core/src/renderer/v8_datastore.cc
@@ -1,14 +1,16 @@
 #include "pengu.h"
 #include "v8_wrapper.h"
 
-#include <atomic>
 #include <mutex>
+#include <optional>
 #include <string>
 
 namespace
 {
+    std::mutex g_datastore_pending_mutex;
     std::mutex g_datastore_write_mutex;
-    std::atomic<uint64_t> g_datastore_save_sequence{ 0 };
+    std::optional<std::string> g_datastore_pending_save;
+    bool g_datastore_save_queued = false;
 }
 
 static void transform_data(void *data, size_t length)
@@ -44,12 +46,35 @@ static void load_datastore(cef_string_t *json)
     }
 }
 
-static void save_datastore(std::string json)
+static void save_datastore(std::string &json)
 {
     auto path = config::datastore_path();
 
     transform_data(json.data(), json.size());
     file::write_file(path, json.data(), json.size());
+}
+
+static void drain_datastore_saves()
+{
+    for (;;)
+    {
+        std::optional<std::string> payload;
+
+        {
+            std::lock_guard<std::mutex> lock(g_datastore_pending_mutex);
+            if (!g_datastore_pending_save.has_value())
+            {
+                g_datastore_save_queued = false;
+                return;
+            }
+
+            payload.emplace(std::move(g_datastore_pending_save.value()));
+            g_datastore_pending_save.reset();
+        }
+
+        std::lock_guard<std::mutex> lock(g_datastore_write_mutex);
+        save_datastore(payload.value());
+    }
 }
 
 static V8Value *v8_load_datastore(V8Value *const args[], int argc)
@@ -74,15 +99,20 @@ static V8Value *v8_save_datastore(V8Value *const args[], int argc)
             cef_string_utf8_t utf8{};
             cef_string_to_utf8(json.str, json.length, &utf8);
 
-            std::string payload(utf8.str, utf8.length);
-            auto sequence = g_datastore_save_sequence.fetch_add(1) + 1;
-            v8_async::enqueue([sequence, payload = std::move(payload)]() mutable {
-                std::lock_guard<std::mutex> lock(g_datastore_write_mutex);
-                if (sequence != g_datastore_save_sequence.load())
-                    return;
+            bool should_queue = false;
+            {
+                std::lock_guard<std::mutex> lock(g_datastore_pending_mutex);
+                g_datastore_pending_save.emplace(utf8.str, utf8.length);
 
-                save_datastore(std::move(payload));
-            });
+                if (!g_datastore_save_queued)
+                {
+                    g_datastore_save_queued = true;
+                    should_queue = true;
+                }
+            }
+
+            if (should_queue)
+                v8_async::enqueue(drain_datastore_saves);
 
             cef_string_utf8_clear(&utf8);
         }

--- a/core/src/renderer/v8_datastore.cc
+++ b/core/src/renderer/v8_datastore.cc
@@ -1,6 +1,16 @@
 #include "pengu.h"
 #include "v8_wrapper.h"
 
+#include <atomic>
+#include <mutex>
+#include <string>
+
+namespace
+{
+    std::mutex g_datastore_write_mutex;
+    std::atomic<uint64_t> g_datastore_save_sequence{ 0 };
+}
+
 static void transform_data(void *data, size_t length)
 {
     static const char key[] = "A5dgY6lz9fpG9kGNiH1mZ";
@@ -34,12 +44,12 @@ static void load_datastore(cef_string_t *json)
     }
 }
 
-static void save_datastore(cef_string_utf8_t *json)
+static void save_datastore(std::string json)
 {
     auto path = config::datastore_path();
 
-    transform_data(json->str, json->length);
-    file::write_file(path, json->str, json->length);
+    transform_data(json.data(), json.size());
+    file::write_file(path, json.data(), json.size());
 }
 
 static V8Value *v8_load_datastore(V8Value *const args[], int argc)
@@ -63,7 +73,16 @@ static V8Value *v8_save_datastore(V8Value *const args[], int argc)
         {
             cef_string_utf8_t utf8{};
             cef_string_to_utf8(json.str, json.length, &utf8);
-            save_datastore(&utf8);
+
+            std::string payload(utf8.str, utf8.length);
+            auto sequence = g_datastore_save_sequence.fetch_add(1) + 1;
+            v8_async::enqueue([sequence, payload = std::move(payload)]() mutable {
+                std::lock_guard<std::mutex> lock(g_datastore_write_mutex);
+                if (sequence != g_datastore_save_sequence.load())
+                    return;
+
+                save_datastore(std::move(payload));
+            });
 
             cef_string_utf8_clear(&utf8);
         }

--- a/core/src/renderer/v8_pluginfs.cc
+++ b/core/src/renderer/v8_pluginfs.cc
@@ -205,7 +205,7 @@ namespace
     {
         auto normalized = normalize_plugin_input(plugin_root_input);
         auto parts = split_relative_path(normalized, false);
-        if (!parts.has_value())
+        if (!parts.has_value() || parts->size() != 1)
             return std::nullopt;
 
         std::error_code ec;

--- a/core/src/renderer/v8_pluginfs.cc
+++ b/core/src/renderer/v8_pluginfs.cc
@@ -205,7 +205,13 @@ namespace
     {
         auto normalized = normalize_plugin_input(plugin_root_input);
         auto parts = split_relative_path(normalized, false);
-        if (!parts.has_value() || parts->size() != 1)
+        if (!parts.has_value())
+            return std::nullopt;
+
+        if (parts->size() != 1 && parts->size() != 2)
+            return std::nullopt;
+
+        if (parts->size() == 2 && !parts->front().string().starts_with("@"))
             return std::nullopt;
 
         std::error_code ec;
@@ -356,7 +362,7 @@ namespace
         auto temp = target.value();
         temp += ".pengu-tmp";
 
-    std::ofstream stream(temp, std::ios::binary | std::ios::trunc);
+        std::ofstream stream(temp, std::ios::binary | std::ios::trunc);
         if (!stream.good())
             return false;
 

--- a/core/src/renderer/v8_pluginfs.cc
+++ b/core/src/renderer/v8_pluginfs.cc
@@ -25,7 +25,7 @@ namespace
 
     struct FileStatResult
     {
-        path file_name;
+        std::string file_name;
         uintmax_t size;
         bool is_dir;
         bool is_file;
@@ -158,6 +158,18 @@ namespace
             normalized.erase(0, 2);
 
         return normalized;
+    }
+
+    static std::string path_to_utf8(const path &value)
+    {
+        auto utf8 = value.u8string();
+        std::string output;
+        output.reserve(utf8.size());
+
+        for (auto ch : utf8)
+            output.push_back(static_cast<char>(ch));
+
+        return output;
     }
 
     static std::string make_token()
@@ -447,10 +459,10 @@ namespace
                 size = 0;
         }
 
-        return FileStatResult{ target->filename(), size, is_dir, is_file };
+        return FileStatResult{ path_to_utf8(target->filename()), size, is_dir, is_file };
     }
 
-    static std::optional<std::vector<path>> list_dir(const std::string &token, const std::string &relative_path)
+    static std::optional<std::vector<std::string>> list_dir(const std::string &token, const std::string &relative_path)
     {
         auto capability = get_capability(token);
         if (!capability.has_value())
@@ -461,10 +473,11 @@ namespace
             return std::nullopt;
 
         auto entries = file::read_dir(target.value());
-        std::vector<path> names;
+        std::vector<std::string> names;
         for (const auto &entry : entries)
         {
-            auto name = entry.string();
+            auto file_name = entry.filename();
+            auto name = path_to_utf8(file_name);
             if (name == "." || name == "..")
                 continue;
 
@@ -473,7 +486,7 @@ namespace
                 continue;
 
             if (file::is_file(full) || file::is_dir(full))
-                names.push_back(entry.filename());
+                names.push_back(name);
         }
 
         return names;
@@ -610,7 +623,7 @@ static V8Value *v8_pluginfs_stat(V8Value *const args[], int argc)
                 return V8Value::undefined();
 
             auto object = V8Object::create();
-            auto name = CefStr::from_path(result->file_name);
+            auto name = CefStr(result->file_name);
             object->set(&u"fileName"_s, V8Value::string(&name), V8_PROPERTY_ATTRIBUTE_READONLY);
             object->set(&u"length"_s, V8Value::number(static_cast<double>(result->size)), V8_PROPERTY_ATTRIBUTE_READONLY);
             object->set(&u"isDir"_s, V8Value::boolean(result->is_dir), V8_PROPERTY_ATTRIBUTE_READONLY);
@@ -638,7 +651,7 @@ static V8Value *v8_pluginfs_ls(V8Value *const args[], int argc)
             auto array = V8Array::create(static_cast<int>(entries->size()));
             for (int index = 0; index < static_cast<int>(entries->size()); ++index)
             {
-                auto value = CefStr::from_path(entries.value()[index]);
+                auto value = CefStr(entries.value()[index]);
                 array->set(index, V8Value::string(&value));
             }
 

--- a/core/src/renderer/v8_pluginfs.cc
+++ b/core/src/renderer/v8_pluginfs.cc
@@ -1,0 +1,670 @@
+#include "pengu.h"
+#include "v8_wrapper.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <fstream>
+#include <mutex>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <system_error>
+#include <unordered_map>
+
+namespace
+{
+    constexpr size_t MAX_TEXT_BYTES = 16 * 1024 * 1024;
+
+    struct Capability
+    {
+        path root;
+        std::string plugin_root;
+    };
+
+    struct FileStatResult
+    {
+        path file_name;
+        uintmax_t size;
+        bool is_dir;
+        bool is_file;
+    };
+
+    std::mutex g_capabilities_mutex;
+    std::unordered_map<std::string, Capability> g_capabilities;
+    std::atomic<uint64_t> g_token_counter{ 1 };
+
+    static std::string to_utf8(V8Value *value)
+    {
+        CefScopedStr str = value->asString();
+        return str.to_utf8();
+    }
+
+    static bool is_windows_reserved_name(const std::string &component)
+    {
+#if OS_WIN
+        if (component.empty())
+            return true;
+
+        if (component.back() == ' ' || component.back() == '.')
+            return true;
+
+        for (unsigned char ch : component)
+        {
+            if (ch < 32)
+                return true;
+
+            switch (ch)
+            {
+            case '<': case '>': case ':': case '"': case '|': case '?': case '*':
+                return true;
+            default:
+                break;
+            }
+        }
+
+        auto base = component;
+        auto dot = base.find('.');
+        if (dot != std::string::npos)
+            base = base.substr(0, dot);
+
+        std::transform(base.begin(), base.end(), base.begin(), [](unsigned char ch) {
+            return static_cast<char>(std::toupper(ch));
+        });
+
+        if (base == "CON" || base == "PRN" || base == "AUX" || base == "NUL" ||
+            base == "CONIN$" || base == "CONOUT$")
+        {
+            return true;
+        }
+
+        if (base.size() == 4 && (base.starts_with("COM") || base.starts_with("LPT")) &&
+            base[3] >= '1' && base[3] <= '9')
+        {
+            return true;
+        }
+#else
+        (void)component;
+#endif
+        return false;
+    }
+
+    static bool path_exists(const path &target)
+    {
+        std::error_code ec;
+        return std::filesystem::exists(target, ec);
+    }
+
+    static path path_from_utf8_component(const std::string &component)
+    {
+        std::u8string utf8_component;
+        utf8_component.reserve(component.size());
+
+        for (unsigned char ch : component)
+            utf8_component.push_back(static_cast<char8_t>(ch));
+
+        return path(utf8_component);
+    }
+
+    static std::optional<std::vector<path>> split_relative_path(const std::string &input, bool allow_empty)
+    {
+        if (input.size() > 4096)
+            return std::nullopt;
+
+        if (input.empty())
+        {
+            if (allow_empty)
+                return std::vector<path>{};
+            return std::nullopt;
+        }
+
+        if (input[0] == '/' || input[0] == '\\')
+            return std::nullopt;
+
+        std::vector<path> parts;
+        size_t start = 0;
+
+        while (start <= input.size())
+        {
+            size_t end = input.find_first_of("/\\", start);
+            std::string component = input.substr(start, end == std::string::npos ? std::string::npos : end - start);
+
+            if (component.empty() || component == "." || component == ".." || component.size() > 255)
+                return std::nullopt;
+
+            if (component.find(':') != std::string::npos || component.find('\0') != std::string::npos)
+                return std::nullopt;
+
+            if (is_windows_reserved_name(component))
+                return std::nullopt;
+
+            parts.push_back(path_from_utf8_component(component));
+
+            if (end == std::string::npos)
+                break;
+            start = end + 1;
+        }
+
+        return parts;
+    }
+
+    static std::string normalize_plugin_input(const std::string &input)
+    {
+        std::string normalized = input;
+        std::replace(normalized.begin(), normalized.end(), '\\', '/');
+
+        while (normalized.starts_with("./"))
+            normalized.erase(0, 2);
+
+        return normalized;
+    }
+
+    static std::string make_token()
+    {
+        static std::random_device rd;
+        static std::mutex random_mutex;
+
+        uint64_t first;
+        uint64_t second;
+
+        {
+            std::lock_guard<std::mutex> lock(random_mutex);
+            first = (static_cast<uint64_t>(rd()) << 32) ^ rd();
+            second = (static_cast<uint64_t>(rd()) << 32) ^ rd();
+        }
+
+        auto counter = g_token_counter.fetch_add(1);
+        auto ticks = static_cast<uint64_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+
+        std::ostringstream stream;
+        stream << std::hex << first << second << counter << ticks;
+        return stream.str();
+    }
+
+    static bool is_same_or_child_path(const path &base, const path &target)
+    {
+        std::error_code ec;
+        auto base_normal = std::filesystem::weakly_canonical(base, ec);
+        if (ec)
+            return false;
+
+        auto target_normal = std::filesystem::weakly_canonical(target, ec);
+        if (ec)
+            return false;
+
+        auto relative = target_normal.lexically_relative(base_normal);
+        if (relative.empty())
+            return target_normal == base_normal;
+
+        auto first = *relative.begin();
+        return first != "..";
+    }
+
+    static std::optional<std::string> grant_capability(const std::string &plugin_root_input)
+    {
+        auto normalized = normalize_plugin_input(plugin_root_input);
+        auto parts = split_relative_path(normalized, false);
+        if (!parts.has_value())
+            return std::nullopt;
+
+        std::error_code ec;
+        auto plugins_root = std::filesystem::weakly_canonical(config::plugins_dir(), ec);
+        if (ec || !file::is_dir(plugins_root))
+            return std::nullopt;
+
+        path root = plugins_root;
+        for (const auto &part : parts.value())
+        {
+            root /= part;
+            if (file::is_symlink(root))
+                return std::nullopt;
+        }
+
+        auto canonical_root = std::filesystem::weakly_canonical(root, ec);
+        if (ec || !file::is_dir(canonical_root) || !file::is_file(canonical_root / "index.js"))
+            return std::nullopt;
+
+        if (!is_same_or_child_path(plugins_root, canonical_root))
+            return std::nullopt;
+
+        auto token = make_token();
+        {
+            std::lock_guard<std::mutex> lock(g_capabilities_mutex);
+            g_capabilities[token] = Capability{ canonical_root, normalized };
+        }
+
+        return token;
+    }
+
+    static std::optional<Capability> get_capability(const std::string &token)
+    {
+        std::lock_guard<std::mutex> lock(g_capabilities_mutex);
+        auto it = g_capabilities.find(token);
+        if (it == g_capabilities.end())
+            return std::nullopt;
+        return it->second;
+    }
+
+    static bool ensure_root_is_available(const Capability &capability)
+    {
+        return file::is_dir(capability.root) && !file::is_symlink(capability.root);
+    }
+
+    static std::optional<path> resolve_existing_path(const Capability &capability, const std::string &relative_input, bool allow_root)
+    {
+        if (!ensure_root_is_available(capability))
+            return std::nullopt;
+
+        auto normalized = normalize_plugin_input(relative_input);
+        auto parts = split_relative_path(normalized, allow_root);
+        if (!parts.has_value())
+            return std::nullopt;
+
+        path current = capability.root;
+        if (parts->empty())
+            return current;
+
+        for (const auto &part : parts.value())
+        {
+            current /= part;
+            if (!path_exists(current) || file::is_symlink(current))
+                return std::nullopt;
+        }
+
+        if (!is_same_or_child_path(capability.root, current))
+            return std::nullopt;
+
+        return current;
+    }
+
+    static std::optional<path> resolve_write_path(const Capability &capability, const std::string &relative_input)
+    {
+        if (!ensure_root_is_available(capability))
+            return std::nullopt;
+
+        auto normalized = normalize_plugin_input(relative_input);
+        auto parts = split_relative_path(normalized, false);
+        if (!parts.has_value() || parts->empty())
+            return std::nullopt;
+
+        path current = capability.root;
+        for (size_t index = 0; index + 1 < parts->size(); ++index)
+        {
+            current /= parts.value()[index];
+            if (!file::is_dir(current) || file::is_symlink(current))
+                return std::nullopt;
+        }
+
+        auto target = current / parts->back();
+        if (path_exists(target) && (file::is_symlink(target) || file::is_dir(target)))
+            return std::nullopt;
+
+        if (!is_same_or_child_path(capability.root, current))
+            return std::nullopt;
+
+        return target;
+    }
+
+    static std::optional<std::string> read_text(const std::string &token, const std::string &relative_path)
+    {
+        auto capability = get_capability(token);
+        if (!capability.has_value())
+            return std::nullopt;
+
+        auto target = resolve_existing_path(capability.value(), relative_path, false);
+        if (!target.has_value() || !file::is_file(target.value()))
+            return std::nullopt;
+
+        std::error_code ec;
+        auto size = std::filesystem::file_size(target.value(), ec);
+        if (ec || size > MAX_TEXT_BYTES)
+            return std::nullopt;
+
+        void *buffer = nullptr;
+        size_t length = 0;
+        if (!file::read_file(target.value(), &buffer, &length))
+            return std::nullopt;
+
+        std::string content(reinterpret_cast<char *>(buffer), length);
+        free(buffer);
+        return content;
+    }
+
+    static bool write_text(const std::string &token, const std::string &relative_path, const std::string &content, bool append)
+    {
+        if (content.size() > MAX_TEXT_BYTES)
+            return false;
+
+        auto capability = get_capability(token);
+        if (!capability.has_value())
+            return false;
+
+        auto target = resolve_write_path(capability.value(), relative_path);
+        if (!target.has_value())
+            return false;
+
+        if (append)
+        {
+            std::ofstream stream(target.value(), std::ios::binary | std::ios::app);
+            if (!stream.good())
+                return false;
+            stream.write(content.data(), static_cast<std::streamsize>(content.size()));
+            return stream.good();
+        }
+
+        auto temp = target.value();
+        temp += ".pengu-tmp";
+
+    std::ofstream stream(temp, std::ios::binary | std::ios::trunc);
+        if (!stream.good())
+            return false;
+
+        stream.write(content.data(), static_cast<std::streamsize>(content.size()));
+        stream.close();
+
+        if (!stream.good())
+        {
+            std::error_code ec;
+            std::filesystem::remove(temp, ec);
+            return false;
+        }
+
+#if OS_WIN
+        return MoveFileExW(temp.wstring().c_str(), target->wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+#else
+        std::error_code ec;
+        std::filesystem::rename(temp, target.value(), ec);
+        if (ec)
+        {
+            std::filesystem::remove(temp, ec);
+            return false;
+        }
+        return true;
+#endif
+    }
+
+    static bool make_dir(const std::string &token, const std::string &relative_path)
+    {
+        auto capability = get_capability(token);
+        if (!capability.has_value() || !ensure_root_is_available(capability.value()))
+            return false;
+
+        auto normalized = normalize_plugin_input(relative_path);
+        auto parts = split_relative_path(normalized, false);
+        if (!parts.has_value() || parts->empty())
+            return false;
+
+        path current = capability->root;
+        bool created = false;
+
+        for (const auto &part : parts.value())
+        {
+            current /= part;
+            if (path_exists(current))
+            {
+                if (!file::is_dir(current) || file::is_symlink(current))
+                    return false;
+                continue;
+            }
+
+            std::error_code ec;
+            if (!std::filesystem::create_directory(current, ec) || ec)
+                return false;
+            created = true;
+        }
+
+        return created && is_same_or_child_path(capability->root, current);
+    }
+
+    static std::optional<FileStatResult> stat_path(const std::string &token, const std::string &relative_path)
+    {
+        auto capability = get_capability(token);
+        if (!capability.has_value())
+            return std::nullopt;
+
+        auto target = resolve_existing_path(capability.value(), relative_path, true);
+        if (!target.has_value())
+            return std::nullopt;
+
+        bool is_dir = file::is_dir(target.value());
+        bool is_file = file::is_file(target.value());
+        if (!is_dir && !is_file)
+            return std::nullopt;
+
+        uintmax_t size = 0;
+        if (is_file)
+        {
+            std::error_code ec;
+            size = std::filesystem::file_size(target.value(), ec);
+            if (ec)
+                size = 0;
+        }
+
+        return FileStatResult{ target->filename(), size, is_dir, is_file };
+    }
+
+    static std::optional<std::vector<path>> list_dir(const std::string &token, const std::string &relative_path)
+    {
+        auto capability = get_capability(token);
+        if (!capability.has_value())
+            return std::nullopt;
+
+        auto target = resolve_existing_path(capability.value(), relative_path, true);
+        if (!target.has_value() || !file::is_dir(target.value()))
+            return std::nullopt;
+
+        auto entries = file::read_dir(target.value());
+        std::vector<path> names;
+        for (const auto &entry : entries)
+        {
+            auto name = entry.string();
+            if (name == "." || name == "..")
+                continue;
+
+            auto full = target.value() / entry;
+            if (file::is_symlink(full))
+                continue;
+
+            if (file::is_file(full) || file::is_dir(full))
+                names.push_back(entry.filename());
+        }
+
+        return names;
+    }
+
+    static uintmax_t remove_path(const std::string &token, const std::string &relative_path, bool recursive)
+    {
+        auto capability = get_capability(token);
+        if (!capability.has_value())
+            return 0;
+
+        auto target = resolve_existing_path(capability.value(), relative_path, false);
+        if (!target.has_value() || target.value() == capability->root)
+            return 0;
+
+        std::error_code ec;
+        if (file::is_dir(target.value()))
+        {
+            if (recursive)
+                return std::filesystem::remove_all(target.value(), ec);
+            return std::filesystem::remove(target.value(), ec) ? 1 : 0;
+        }
+
+        if (file::is_file(target.value()))
+            return std::filesystem::remove(target.value(), ec) ? 1 : 0;
+
+        return 0;
+    }
+
+    static V8Value *resolve_undefined()
+    {
+        auto task = new V8PromiseTask();
+        return task->execute([task] {
+            task->resolve([] { return V8Value::undefined(); });
+        });
+    }
+
+    static V8Value *resolve_boolean(bool value)
+    {
+        auto task = new V8PromiseTask();
+        return task->execute([task, value] {
+            task->resolve([value] { return V8Value::boolean(value); });
+        });
+    }
+
+    static V8Value *resolve_number(uintmax_t value)
+    {
+        auto task = new V8PromiseTask();
+        return task->execute([task, value] {
+            task->resolve([value] { return V8Value::number(static_cast<double>(value)); });
+        });
+    }
+}
+
+static V8Value *v8_pluginfs_grant(V8Value *const args[], int argc)
+{
+    if (argc < 1 || !args[0]->isString())
+        return V8Value::undefined();
+
+    auto token = grant_capability(to_utf8(args[0]));
+    if (!token.has_value())
+        return V8Value::undefined();
+
+    CefStr value(token.value());
+    return V8Value::string(&value);
+}
+
+static V8Value *v8_pluginfs_read(V8Value *const args[], int argc)
+{
+    if (argc < 2 || !args[0]->isString() || !args[1]->isString())
+        return resolve_undefined();
+
+    auto token = to_utf8(args[0]);
+    auto relative_path = to_utf8(args[1]);
+
+    auto task = new V8PromiseTask();
+    return task->execute([task, token, relative_path] {
+        auto content = read_text(token, relative_path);
+        task->resolve([content] {
+            if (!content.has_value())
+                return V8Value::undefined();
+
+            CefStr value(content.value());
+            return V8Value::string(&value);
+        });
+    });
+}
+
+static V8Value *v8_pluginfs_write(V8Value *const args[], int argc)
+{
+    if (argc < 3 || !args[0]->isString() || !args[1]->isString() || !args[2]->isString())
+        return resolve_boolean(false);
+
+    auto token = to_utf8(args[0]);
+    auto relative_path = to_utf8(args[1]);
+    auto content = to_utf8(args[2]);
+    bool append = argc > 3 && args[3]->isBool() && args[3]->asBool();
+
+    auto task = new V8PromiseTask();
+    return task->execute([task, token, relative_path, content, append] {
+        bool result = write_text(token, relative_path, content, append);
+        task->resolve([result] { return V8Value::boolean(result); });
+    });
+}
+
+static V8Value *v8_pluginfs_mkdir(V8Value *const args[], int argc)
+{
+    if (argc < 2 || !args[0]->isString() || !args[1]->isString())
+        return resolve_boolean(false);
+
+    auto token = to_utf8(args[0]);
+    auto relative_path = to_utf8(args[1]);
+
+    auto task = new V8PromiseTask();
+    return task->execute([task, token, relative_path] {
+        bool result = make_dir(token, relative_path);
+        task->resolve([result] { return V8Value::boolean(result); });
+    });
+}
+
+static V8Value *v8_pluginfs_stat(V8Value *const args[], int argc)
+{
+    if (argc < 2 || !args[0]->isString() || !args[1]->isString())
+        return resolve_undefined();
+
+    auto token = to_utf8(args[0]);
+    auto relative_path = to_utf8(args[1]);
+
+    auto task = new V8PromiseTask();
+    return task->execute([task, token, relative_path] {
+        auto result = stat_path(token, relative_path);
+        task->resolve([result] {
+            if (!result.has_value())
+                return V8Value::undefined();
+
+            auto object = V8Object::create();
+            auto name = CefStr::from_path(result->file_name);
+            object->set(&u"fileName"_s, V8Value::string(&name), V8_PROPERTY_ATTRIBUTE_READONLY);
+            object->set(&u"length"_s, V8Value::number(static_cast<double>(result->size)), V8_PROPERTY_ATTRIBUTE_READONLY);
+            object->set(&u"isDir"_s, V8Value::boolean(result->is_dir), V8_PROPERTY_ATTRIBUTE_READONLY);
+            object->set(&u"isFile"_s, V8Value::boolean(result->is_file), V8_PROPERTY_ATTRIBUTE_READONLY);
+            return reinterpret_cast<V8Value *>(object);
+        });
+    });
+}
+
+static V8Value *v8_pluginfs_ls(V8Value *const args[], int argc)
+{
+    if (argc < 2 || !args[0]->isString() || !args[1]->isString())
+        return resolve_undefined();
+
+    auto token = to_utf8(args[0]);
+    auto relative_path = to_utf8(args[1]);
+
+    auto task = new V8PromiseTask();
+    return task->execute([task, token, relative_path] {
+        auto entries = list_dir(token, relative_path);
+        task->resolve([entries] {
+            if (!entries.has_value())
+                return V8Value::undefined();
+
+            auto array = V8Array::create(static_cast<int>(entries->size()));
+            for (int index = 0; index < static_cast<int>(entries->size()); ++index)
+            {
+                auto value = CefStr::from_path(entries.value()[index]);
+                array->set(index, V8Value::string(&value));
+            }
+
+            return reinterpret_cast<V8Value *>(array);
+        });
+    });
+}
+
+static V8Value *v8_pluginfs_remove(V8Value *const args[], int argc)
+{
+    if (argc < 2 || !args[0]->isString() || !args[1]->isString())
+        return resolve_number(0);
+
+    auto token = to_utf8(args[0]);
+    auto relative_path = to_utf8(args[1]);
+    bool recursive = argc > 2 && args[2]->isBool() && args[2]->asBool();
+
+    auto task = new V8PromiseTask();
+    return task->execute([task, token, relative_path, recursive] {
+        auto result = remove_path(token, relative_path, recursive);
+        task->resolve([result] { return V8Value::number(static_cast<double>(result)); });
+    });
+}
+
+V8HandlerFunctionEntry v8_PluginFSEntries[]
+{
+    { "PluginFSGrant", v8_pluginfs_grant },
+    { "PluginFSRead", v8_pluginfs_read },
+    { "PluginFSWrite", v8_pluginfs_write },
+    { "PluginFSMkdir", v8_pluginfs_mkdir },
+    { "PluginFSStat", v8_pluginfs_stat },
+    { "PluginFSLs", v8_pluginfs_ls },
+    { "PluginFSRemove", v8_pluginfs_remove },
+    { nullptr },
+};

--- a/core/src/renderer/v8_pluginfs.cc
+++ b/core/src/renderer/v8_pluginfs.cc
@@ -32,8 +32,10 @@ namespace
     };
 
     std::mutex g_capabilities_mutex;
+    std::mutex g_write_mutex;
     std::unordered_map<std::string, Capability> g_capabilities;
     std::atomic<uint64_t> g_token_counter{ 1 };
+    std::atomic<uint64_t> g_temp_counter{ 1 };
 
     static std::string to_utf8(V8Value *value)
     {
@@ -362,6 +364,8 @@ namespace
         if (!target.has_value())
             return false;
 
+        std::lock_guard<std::mutex> write_lock(g_write_mutex);
+
         if (append)
         {
             std::ofstream stream(target.value(), std::ios::binary | std::ios::app);
@@ -372,7 +376,8 @@ namespace
         }
 
         auto temp = target.value();
-        temp += ".pengu-tmp";
+        temp += ".pengu-tmp.";
+        temp += std::to_string(g_temp_counter.fetch_add(1));
 
         std::ofstream stream(temp, std::ios::binary | std::ios::trunc);
         if (!stream.good())

--- a/core/src/renderer/v8_wrapper.h
+++ b/core/src/renderer/v8_wrapper.h
@@ -2,6 +2,11 @@
 #define _V8_WRAPPER_H_
 
 #include "include/capi/cef_v8_capi.h"
+#include "include/capi/cef_task_capi.h"
+#include <functional>
+#include <optional>
+#include <stdexcept>
+#include <thread>
 
 struct V8ValueBase
 {
@@ -27,6 +32,7 @@ struct V8Value : V8ValueBase
     inline bool isObject() { return _.is_object(&_); }
     inline bool isArray() { return _.is_array(&_); }
     inline bool isFunction() { return _.is_function(&_); }
+    inline bool isPromise() { return _.is_promise(&_); }
 
     inline bool asBool() { return _.get_bool_value(&_); }
     inline int asInt() { return _.get_int_value(&_); }
@@ -36,6 +42,7 @@ struct V8Value : V8ValueBase
 
     inline struct V8Array *asArray() { return reinterpret_cast<struct V8Array *>(&_); }
     inline struct V8Object *asObject() { return reinterpret_cast<struct V8Object *>(&_); }
+    inline struct V8Promise *asPromise() { return reinterpret_cast<struct V8Promise *>(&_); }
 
     static inline V8Value *undefined()
     {
@@ -116,6 +123,90 @@ struct V8Object : V8ValueBase
     static inline V8Object *create()
     {
         return (V8Object *)cef_v8value_create_object(nullptr, nullptr);
+    }
+};
+
+class V8PromiseTask : CefRefCount<cef_task_t>
+{
+private:
+    cef_v8context_t *context_;
+    cef_v8value_t *promise_;
+    std::optional<std::function<V8Value *()>> resolver_;
+
+    static void CALLBACK _execute(cef_task_t *self)
+    {
+        auto *task = reinterpret_cast<V8PromiseTask *>(self);
+        task->execute_in_renderer();
+    }
+
+    void execute_in_renderer()
+    {
+        context_->enter(context_);
+
+        if (resolver_.has_value())
+        {
+            try
+            {
+                auto value = resolver_.value()();
+                promise_->resolve_promise(promise_, value ? value->ptr() : nullptr);
+            }
+            catch (const std::exception &ex)
+            {
+                CefStr message(ex.what());
+                promise_->reject_promise(promise_, &message);
+            }
+        }
+        else
+        {
+            promise_->resolve_promise(promise_, nullptr);
+        }
+
+        promise_->base.release(&promise_->base);
+        context_->exit(context_);
+    }
+
+public:
+    V8PromiseTask() : CefRefCount(this), resolver_(std::nullopt)
+    {
+        cef_task_t::execute = _execute;
+
+        context_ = cef_v8context_get_current_context();
+        context_->base.add_ref(&context_->base);
+
+        context_->enter(context_);
+        promise_ = cef_v8value_create_promise();
+        promise_->base.add_ref(&promise_->base);
+        context_->exit(context_);
+    }
+
+    ~V8PromiseTask()
+    {
+        context_->base.release(&context_->base);
+    }
+
+    void resolve()
+    {
+        resolver_ = std::nullopt;
+        cef_post_task(TID_RENDERER, this);
+    }
+
+    void resolve(std::function<V8Value *()> &&resolver)
+    {
+        resolver_ = resolver;
+        cef_post_task(TID_RENDERER, this);
+    }
+
+    void reject(const std::string &error)
+    {
+        resolve([error]() -> V8Value * {
+            throw std::runtime_error(error);
+        });
+    }
+
+    V8Value *execute(std::function<void()> &&runner)
+    {
+        std::thread(runner).detach();
+        return reinterpret_cast<V8Value *>(promise_);
     }
 };
 

--- a/core/src/renderer/v8_wrapper.h
+++ b/core/src/renderer/v8_wrapper.h
@@ -298,7 +298,20 @@ public:
 
     V8Value *execute(std::function<void()> &&runner)
     {
-        v8_async::enqueue(std::move(runner));
+        v8_async::enqueue([this, runner = std::move(runner)]() mutable {
+            try
+            {
+                runner();
+            }
+            catch (const std::exception &ex)
+            {
+                reject(ex.what());
+            }
+            catch (...)
+            {
+                reject("Async task failed");
+            }
+        });
         return reinterpret_cast<V8Value *>(promise_);
     }
 };

--- a/core/src/renderer/v8_wrapper.h
+++ b/core/src/renderer/v8_wrapper.h
@@ -3,6 +3,7 @@
 
 #include "include/capi/cef_v8_capi.h"
 #include "include/capi/cef_task_capi.h"
+#include "platform.h"
 #include <condition_variable>
 #include <deque>
 #include <functional>
@@ -226,6 +227,28 @@ private:
     cef_v8value_t *promise_;
     std::optional<std::function<V8Value *()>> resolver_;
 
+    cef_v8value_t *create_promise()
+    {
+#if OS_MAC
+        CefStr code("new Promise(() => {})");
+        CefStr script_url("pengu://native-promise");
+        cef_v8value_t *value = nullptr;
+        cef_v8exception_t *exception = nullptr;
+
+        if (!context_->eval(context_, &code, &script_url, 1, &value, &exception) || value == nullptr)
+        {
+            if (exception != nullptr)
+                exception->base.release(&exception->base);
+
+            return cef_v8value_create_undefined();
+        }
+
+        return value;
+#else
+        return cef_v8value_create_promise();
+#endif
+    }
+
     static void CALLBACK _execute(cef_task_t *self)
     {
         auto *task = reinterpret_cast<V8PromiseTask *>(self);
@@ -267,7 +290,7 @@ public:
         context_->base.add_ref(&context_->base);
 
         context_->enter(context_);
-        promise_ = cef_v8value_create_promise();
+        promise_ = create_promise();
         promise_->base.add_ref(&promise_->base);
         context_->exit(context_);
     }

--- a/core/src/renderer/v8_wrapper.h
+++ b/core/src/renderer/v8_wrapper.h
@@ -3,10 +3,103 @@
 
 #include "include/capi/cef_v8_capi.h"
 #include "include/capi/cef_task_capi.h"
+#include <condition_variable>
+#include <deque>
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <thread>
+#include <vector>
+
+namespace v8_async
+{
+    class TaskPool
+    {
+    private:
+        static constexpr size_t WORKER_COUNT = 4;
+
+        std::mutex mutex_;
+        std::condition_variable condition_;
+        std::deque<std::function<void()>> queue_;
+        std::vector<std::thread> workers_;
+        bool stopping_ = false;
+
+        TaskPool()
+        {
+            workers_.reserve(WORKER_COUNT);
+            for (size_t index = 0; index < WORKER_COUNT; ++index)
+            {
+                workers_.emplace_back([this] { run(); });
+            }
+        }
+
+        ~TaskPool()
+        {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                stopping_ = true;
+            }
+
+            condition_.notify_all();
+
+            for (auto &worker : workers_)
+            {
+                if (worker.joinable())
+                    worker.join();
+            }
+        }
+
+        void run()
+        {
+            for (;;)
+            {
+                std::function<void()> task;
+
+                {
+                    std::unique_lock<std::mutex> lock(mutex_);
+                    condition_.wait(lock, [this] { return stopping_ || !queue_.empty(); });
+
+                    if (stopping_ && queue_.empty())
+                        return;
+
+                    task = std::move(queue_.front());
+                    queue_.pop_front();
+                }
+
+                task();
+            }
+        }
+
+    public:
+        TaskPool(const TaskPool &) = delete;
+        TaskPool &operator=(const TaskPool &) = delete;
+
+        static TaskPool &instance()
+        {
+            static TaskPool pool;
+            return pool;
+        }
+
+        void enqueue(std::function<void()> &&task)
+        {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                if (stopping_)
+                    return;
+
+                queue_.push_back(std::move(task));
+            }
+
+            condition_.notify_one();
+        }
+    };
+
+    inline void enqueue(std::function<void()> &&task)
+    {
+        TaskPool::instance().enqueue(std::move(task));
+    }
+}
 
 struct V8ValueBase
 {
@@ -205,7 +298,7 @@ public:
 
     V8Value *execute(std::function<void()> &&runner)
     {
-        std::thread(runner).detach();
+        v8_async::enqueue(std::move(runner));
         return reinterpret_cast<V8Value *>(promise_);
     }
 };

--- a/core/src/utils/file.cc
+++ b/core/src/utils/file.cc
@@ -16,6 +16,10 @@ bool file::is_symlink(const path &path)
 
     return attr & FILE_ATTRIBUTE_REPARSE_POINT;
 #elif OS_MAC
+    struct stat buffer;
+    if (lstat(path.string().c_str(), &buffer) == 0) {
+        return S_ISLNK(buffer.st_mode);
+    }
     return false;
 #endif
 }

--- a/plugins/src/preload/api/PluginBus.ts
+++ b/plugins/src/preload/api/PluginBus.ts
@@ -1,0 +1,147 @@
+type PluginEventHandler = (payload: unknown, event: PluginBusEvent) => unknown;
+
+type PluginBusEvent = {
+  topic: string
+  source: string
+  timestamp: number
+}
+
+type PluginSubscription = {
+  owner: string
+  handler: PluginEventHandler
+  once: boolean
+}
+
+const subscriptions = new Map<string, Set<PluginSubscription>>();
+
+function normalizeTopic(topic: string) {
+  const normalized = String(topic);
+
+  if (!normalized || normalized.length > 128 || /[\0\r\n]/.test(normalized))
+    throw new TypeError('Invalid plugin bus topic');
+
+  return normalized;
+}
+
+function reportHandlerError(owner: string, topic: string, error: unknown) {
+  console.error('%c Pengu ', 'background: #183461; color: #fff', `Plugin bus handler failed for "${topic}" in "${owner}".`, error);
+}
+
+export function createPluginBus(pluginName: string) {
+  const bus = {
+    on(topic: string, handler: PluginEventHandler) {
+      if (typeof handler !== 'function')
+        throw new TypeError('Plugin bus handler must be a function');
+
+      const topicName = normalizeTopic(topic);
+      const subscription = { owner: pluginName, handler, once: false };
+      let topicSubscriptions = subscriptions.get(topicName);
+
+      if (!topicSubscriptions) {
+        topicSubscriptions = new Set<PluginSubscription>();
+        subscriptions.set(topicName, topicSubscriptions);
+      }
+
+      topicSubscriptions.add(subscription);
+
+      let active = true;
+      return () => {
+        if (!active)
+          return;
+
+        active = false;
+        const currentSubscriptions = subscriptions.get(topicName);
+        if (!currentSubscriptions)
+          return;
+
+        currentSubscriptions.delete(subscription);
+        if (!currentSubscriptions.size)
+          subscriptions.delete(topicName);
+      };
+    },
+
+    once(topic: string, handler: PluginEventHandler) {
+      if (typeof handler !== 'function')
+        throw new TypeError('Plugin bus handler must be a function');
+
+      const topicName = normalizeTopic(topic);
+      const subscription = { owner: pluginName, handler, once: true };
+      let topicSubscriptions = subscriptions.get(topicName);
+
+      if (!topicSubscriptions) {
+        topicSubscriptions = new Set<PluginSubscription>();
+        subscriptions.set(topicName, topicSubscriptions);
+      }
+
+      topicSubscriptions.add(subscription);
+
+      let active = true;
+      return () => {
+        if (!active)
+          return;
+
+        active = false;
+        const currentSubscriptions = subscriptions.get(topicName);
+        if (!currentSubscriptions)
+          return;
+
+        currentSubscriptions.delete(subscription);
+        if (!currentSubscriptions.size)
+          subscriptions.delete(topicName);
+      };
+    },
+
+    off(topic: string, handler: PluginEventHandler) {
+      const topicName = normalizeTopic(topic);
+      const topicSubscriptions = subscriptions.get(topicName);
+      if (!topicSubscriptions)
+        return;
+
+      for (const subscription of Array.from(topicSubscriptions)) {
+        if (subscription.owner === pluginName && subscription.handler === handler)
+          topicSubscriptions.delete(subscription);
+      }
+
+      if (!topicSubscriptions.size)
+        subscriptions.delete(topicName);
+    },
+
+    emit(topic: string, payload?: unknown) {
+      const topicName = normalizeTopic(topic);
+      const topicSubscriptions = Array.from(subscriptions.get(topicName) ?? []);
+      if (!topicSubscriptions.length)
+        return 0;
+
+      const currentSubscriptions = subscriptions.get(topicName);
+      if (currentSubscriptions) {
+        for (const subscription of topicSubscriptions) {
+          if (subscription.once)
+            currentSubscriptions.delete(subscription);
+        }
+
+        if (!currentSubscriptions.size)
+          subscriptions.delete(topicName);
+      }
+
+      const event = Object.freeze({
+        topic: topicName,
+        source: pluginName,
+        timestamp: Date.now(),
+      });
+
+      for (const subscription of topicSubscriptions) {
+        queueMicrotask(() => {
+          try {
+            subscription.handler(payload, event);
+          } catch (error) {
+            reportHandlerError(subscription.owner, topicName, error);
+          }
+        });
+      }
+
+      return topicSubscriptions.length;
+    },
+  };
+
+  return Object.freeze(bus);
+}

--- a/plugins/src/preload/api/PluginFS.ts
+++ b/plugins/src/preload/api/PluginFS.ts
@@ -1,0 +1,64 @@
+import { native } from './native';
+
+type WriteOptions = {
+  append?: boolean
+}
+
+type RemoveOptions = {
+  recursive?: boolean
+}
+
+function normalizePath(path: string | undefined) {
+  if (!path)
+    return '';
+
+  path = String(path).replace(/\\/g, '/');
+
+  while (path.startsWith('./'))
+    path = path.substring(2);
+
+  while (path.startsWith('/'))
+    path = path.substring(1);
+
+  return path;
+}
+
+export class PluginFileSystem implements PluginFS {
+  #token: string;
+
+  constructor(token: string) {
+    this.#token = token;
+  }
+
+  read(path: string) {
+    return native.PluginFSRead(this.#token, normalizePath(path));
+  }
+
+  write(path: string, content: string, options: WriteOptions = {}) {
+    return native.PluginFSWrite(this.#token, normalizePath(path), String(content), Boolean(options.append));
+  }
+
+  mkdir(path: string) {
+    return native.PluginFSMkdir(this.#token, normalizePath(path));
+  }
+
+  stat(path: string = '') {
+    return native.PluginFSStat(this.#token, normalizePath(path));
+  }
+
+  ls(path: string = '') {
+    return native.PluginFSLs(this.#token, normalizePath(path));
+  }
+
+  rm(path: string, options: RemoveOptions = {}) {
+    return native.PluginFSRemove(this.#token, normalizePath(path), Boolean(options.recursive));
+  }
+}
+
+export function createPluginFS(pluginRoot: string) {
+  const token = native.PluginFSGrant(pluginRoot);
+  if (!token)
+    return undefined;
+
+  return Object.freeze(new PluginFileSystem(token));
+}

--- a/plugins/src/preload/api/PluginFS.ts
+++ b/plugins/src/preload/api/PluginFS.ts
@@ -1,5 +1,8 @@
 import { native } from './native';
 
+const grantPluginFS = native.PluginFSGrant;
+delete (native as unknown as Record<string, unknown>).PluginFSGrant;
+
 type WriteOptions = {
   append?: boolean
 }
@@ -23,42 +26,34 @@ function normalizePath(path: string | undefined) {
   return path;
 }
 
-export class PluginFileSystem implements PluginFS {
-  #token: string;
-
-  constructor(token: string) {
-    this.#token = token;
-  }
-
-  read(path: string) {
-    return native.PluginFSRead(this.#token, normalizePath(path));
-  }
-
-  write(path: string, content: string, options: WriteOptions = {}) {
-    return native.PluginFSWrite(this.#token, normalizePath(path), String(content), Boolean(options.append));
-  }
-
-  mkdir(path: string) {
-    return native.PluginFSMkdir(this.#token, normalizePath(path));
-  }
-
-  stat(path: string = '') {
-    return native.PluginFSStat(this.#token, normalizePath(path));
-  }
-
-  ls(path: string = '') {
-    return native.PluginFSLs(this.#token, normalizePath(path));
-  }
-
-  rm(path: string, options: RemoveOptions = {}) {
-    return native.PluginFSRemove(this.#token, normalizePath(path), Boolean(options.recursive));
-  }
-}
-
 export function createPluginFS(pluginRoot: string) {
-  const token = native.PluginFSGrant(pluginRoot);
+  const token = grantPluginFS(pluginRoot);
   if (!token)
     return undefined;
 
-  return Object.freeze(new PluginFileSystem(token));
+  return Object.freeze({
+    read(path: string) {
+      return native.PluginFSRead(token, normalizePath(path));
+    },
+
+    write(path: string, content: string, options: WriteOptions = {}) {
+      return native.PluginFSWrite(token, normalizePath(path), String(content), Boolean(options.append));
+    },
+
+    mkdir(path: string) {
+      return native.PluginFSMkdir(token, normalizePath(path));
+    },
+
+    stat(path: string = '') {
+      return native.PluginFSStat(token, normalizePath(path));
+    },
+
+    ls(path: string = '') {
+      return native.PluginFSLs(token, normalizePath(path));
+    },
+
+    rm(path: string, options: RemoveOptions = {}) {
+      return native.PluginFSRemove(token, normalizePath(path), Boolean(options.recursive));
+    },
+  });
 }

--- a/plugins/src/preload/api/native.ts
+++ b/plugins/src/preload/api/native.ts
@@ -14,4 +14,12 @@ interface Native {
 
   LoadDataStore: () => string;
   SaveDataStore: (data: string) => void;
+
+  PluginFSGrant: (pluginRoot: string) => string | undefined;
+  PluginFSRead: (token: string, path: string) => Promise<string | undefined>;
+  PluginFSWrite: (token: string, path: string, content: string, append: boolean) => Promise<boolean>;
+  PluginFSMkdir: (token: string, path: string) => Promise<boolean>;
+  PluginFSStat: (token: string, path: string) => Promise<FileStat | undefined>;
+  PluginFSLs: (token: string, path: string) => Promise<string[] | undefined>;
+  PluginFSRemove: (token: string, path: string, recursive: boolean) => Promise<number>;
 }

--- a/plugins/src/preload/loader.ts
+++ b/plugins/src/preload/loader.ts
@@ -21,10 +21,17 @@ function getDirectoryPluginRoot(entry: string) {
     return '';
 
   const pluginRoot = entry.substring(0, entry.length - '/index.js'.length);
-  if (!pluginRoot || pluginRoot.includes('/'))
+  if (!pluginRoot)
     return '';
 
-  return pluginRoot;
+  const parts = pluginRoot.split('/');
+  if (parts.length === 1)
+    return pluginRoot;
+
+  if (parts.length === 2 && parts[0].startsWith('@') && parts[1])
+    return pluginRoot;
+
+  return '';
 }
 
 if ('disabledPlugins' in window.Pengu) {

--- a/plugins/src/preload/loader.ts
+++ b/plugins/src/preload/loader.ts
@@ -1,4 +1,5 @@
 import { rcp, socket } from './rcp';
+import { createPluginFS } from './api/PluginFS';
 
 const plugins = window.Pengu.plugins
 
@@ -41,18 +42,24 @@ async function loadPlugin(entry: string) {
   let stage = 'load';
   try {
     // Acquire plugin
-    const url = `https://plugins/${entry}`;
+    const normalizedEntry = entry.replace(/\\/g, '/');
+    const url = `https://plugins/${normalizedEntry}`;
     const plugin: Plugin = await import(url);
 
     // Init immediately
     if (typeof plugin.init === 'function') {
       stage = 'initialize';
-      const pluginName = entry.substring(0, entry.indexOf('/'));
+      const pluginRoot = normalizedEntry.endsWith('/index.js')
+        ? normalizedEntry.substring(0, normalizedEntry.length - '/index.js'.length)
+        : '';
       const initContext = { rcp, socket };
       // If it's not top-level JS
-      if (pluginName) {
-        const meta = { name: pluginName };
+      if (pluginRoot) {
+        const meta = { name: pluginRoot };
+        const fs = createPluginFS(pluginRoot);
         initContext['meta'] = meta;
+        if (fs)
+          initContext['fs'] = fs;
       }
       await plugin.init(initContext);
     }

--- a/plugins/src/preload/loader.ts
+++ b/plugins/src/preload/loader.ts
@@ -1,7 +1,31 @@
 import { rcp, socket } from './rcp';
 import { createPluginFS } from './api/PluginFS';
+import { createPluginBus } from './api/PluginBus';
 
 const plugins = window.Pengu.plugins
+
+function normalizeEntry(entry: string) {
+  let normalized = entry.replace(/\\/g, '/');
+
+  while (normalized.startsWith('./'))
+    normalized = normalized.substring(2);
+
+  while (normalized.startsWith('/'))
+    normalized = normalized.substring(1);
+
+  return normalized;
+}
+
+function getDirectoryPluginRoot(entry: string) {
+  if (!entry.endsWith('/index.js'))
+    return '';
+
+  const pluginRoot = entry.substring(0, entry.length - '/index.js'.length);
+  if (!pluginRoot || pluginRoot.includes('/'))
+    return '';
+
+  return pluginRoot;
+}
 
 if ('disabledPlugins' in window.Pengu) {
   const blacklist = new Set<number>
@@ -42,18 +66,17 @@ async function loadPlugin(entry: string) {
   let stage = 'load';
   try {
     // Acquire plugin
-    const normalizedEntry = entry.replace(/\\/g, '/');
+    const normalizedEntry = normalizeEntry(entry);
     const url = `https://plugins/${normalizedEntry}`;
     const plugin: Plugin = await import(url);
 
     // Init immediately
     if (typeof plugin.init === 'function') {
       stage = 'initialize';
-      const pluginRoot = normalizedEntry.endsWith('/index.js')
-        ? normalizedEntry.substring(0, normalizedEntry.length - '/index.js'.length)
-        : '';
-      const initContext = { rcp, socket };
-      // If it's not top-level JS
+      const pluginRoot = getDirectoryPluginRoot(normalizedEntry);
+      const pluginName = pluginRoot || normalizedEntry;
+      const initContext: PluginContext = { rcp, socket, bus: createPluginBus(pluginName) };
+
       if (pluginRoot) {
         const meta = { name: pluginRoot };
         const fs = createPluginFS(pluginRoot);

--- a/plugins/src/types.d.ts
+++ b/plugins/src/types.d.ts
@@ -1,9 +1,18 @@
 // internal types
 
 interface Plugin {
-  init?: (context: any) => any
+  init?: (context: PluginContext) => any
   load?: () => any
   default?: Function | any
+}
+
+interface PluginContext {
+  rcp: any
+  socket: any
+  meta?: {
+    name: string
+  }
+  fs?: PluginFS
 }
 
 interface RcpAnnouceEvent extends CustomEvent {
@@ -87,4 +96,20 @@ declare interface Window {
   getScriptPath: () => string | undefined;
 
   __llver: string;
+}
+
+interface FileStat {
+  fileName: string
+  length: number
+  isDir: boolean
+  isFile: boolean
+}
+
+interface PluginFS {
+  read: (path: string) => Promise<string | undefined>
+  write: (path: string, content: string, options?: { append?: boolean }) => Promise<boolean>
+  mkdir: (path: string) => Promise<boolean>
+  stat: (path?: string) => Promise<FileStat | undefined>
+  ls: (path?: string) => Promise<string[] | undefined>
+  rm: (path: string, options?: { recursive?: boolean }) => Promise<number>
 }

--- a/plugins/src/types.d.ts
+++ b/plugins/src/types.d.ts
@@ -9,6 +9,7 @@ interface Plugin {
 interface PluginContext {
   rcp: any
   socket: any
+  bus: PluginBus
   meta?: {
     name: string
   }
@@ -112,4 +113,17 @@ interface PluginFS {
   stat: (path?: string) => Promise<FileStat | undefined>
   ls: (path?: string) => Promise<string[] | undefined>
   rm: (path: string, options?: { recursive?: boolean }) => Promise<number>
+}
+
+interface PluginBusEvent {
+  topic: string
+  source: string
+  timestamp: number
+}
+
+interface PluginBus {
+  on: (topic: string, handler: (payload: unknown, event: PluginBusEvent) => unknown) => () => void
+  once: (topic: string, handler: (payload: unknown, event: PluginBusEvent) => unknown) => () => void
+  off: (topic: string, handler: (payload: unknown, event: PluginBusEvent) => unknown) => void
+  emit: (topic: string, payload?: unknown) => number
 }


### PR DESCRIPTION
## Summary

This PR reintroduces a scoped PluginFS for directory plugins and adds an in-memory plugin event bus for intentional cross-plugin communication.

## Important: macOS verification required

**macOS support must be treated as unverified until someone tests this PR on a real macOS machine.**

I do not have a macOS laptop, so I cannot validate the injected LCUX runtime behavior myself. Windows has been tested live, but that does **not** prove macOS PluginFS works in the actual League Client environment.

There was already one macOS-specific blocker during this work: the macOS CEF library did not export `cef_v8value_create_promise`. This PR includes a fix by creating native promises through the current V8 context instead of linking directly to that missing CEF export. That should unblock the macOS build path, but it still needs real runtime verification.

Please do **not** consider macOS PluginFS support confirmed from this PR alone. Before merging, or at minimum before calling macOS supported, someone with a real Mac should run this smoke test:

- install the PR artifact on real macOS hardware
- run League Client with Pengu injected
- run a folder plugin such as `plugins/pluginfs-smoke/index.js`
- confirm the plugin receives `context.fs`
- confirm `mkdir`, `write`, `read`, `stat`, `ls`, and `rm` all resolve successfully
- confirm traversal such as `../other-plugin/index.js` is rejected
- confirm absolute paths are rejected
- confirm directory listing with non-ASCII filenames does not crash or restart the client

### PluginFS

- Adds native capability tokens scoped to each directory plugin root.
- Exposes `context.fs` only to folder plugins such as `plugins/my-plugin/index.js` and `plugins/@author/plugin/index.js`.
- Supports async `read`, `write`, `mkdir`, `stat`, `ls`, and `rm` operations.
- Hardens path handling against traversal, absolute paths, drive-prefixed paths, reserved Windows names, and symlink/reparse escapes.
- Keeps the native PluginFS grant hidden from plugin code after the JS wrapper captures it.
- Uses a bounded worker pool for async filesystem work instead of spawning a thread per operation.
- Serializes native write operations and uses unique temp filenames for replacement writes, avoiding same-file write races from fire-and-forget plugin save patterns.
- Queues legacy DataStore save commits onto the shared native worker pool so DataStore.set/remove no longer performs encryption and disk writes on the renderer call path.
- Coalesces rapid DataStore saves into a single pending latest snapshot, avoiding a worker task and full JSON payload per set/remove during interval-heavy plugin behavior.
- Handles directory entries as UTF-8 strings and catches worker exceptions so bad filenames or filesystem failures reject promises instead of crashing the renderer.

### Plugin communication

- Adds `context.bus` as a frozen in-memory pub/sub API with `on`, `once`, `off`, and `emit`.
- This gives plugins a supported JS-memory communication path instead of reading/writing each other's plugin folders.

## Local validation

- Windows Release x64 core build passes with MSBuild, including the coalesced async DataStore commit change.
- Plugin preload TypeScript/build passes with pnpm.
- Live LCUX CDP validation on Windows confirmed:
  - folder plugin receives PluginFS
  - Background Customizer loads as `plugins/Background-Customizer/index.js`
  - Background Customizer creates its PluginFS folders and writes `data/skins.cache.json`
  - non-ASCII filename directory listing repro completes without client restart
  - cross-plugin traversal is denied by the PluginFS test plugin
  - concurrent same-file writes from an Elaina-style fire-and-forget persistence pattern all return `true` and preserve the final write
  - boolean append behavior was tested with the current object-options API contract

## Not included

Documentation/research notes are intentionally not included in this PR.


