### PR TITLE
Fix Discord stream handoff in Universal mode

### DIFF
--- a/core/src/dllmain.cc
+++ b/core/src/dllmain.cc
@@ -8,8 +8,46 @@ void HookRendererProcess();
 
 #if OS_WIN
 
+#include <tlhelp32.h>
+
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 void InjectThisDll(HANDLE hProcess);
+
+static DWORD GetParentProcessId(DWORD processId)
+{
+    DWORD parentId = 0;
+    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (snapshot == INVALID_HANDLE_VALUE)
+        return 0;
+
+    PROCESSENTRY32W entry{};
+    entry.dwSize = sizeof(entry);
+
+    if (Process32FirstW(snapshot, &entry))
+    {
+        do
+        {
+            if (entry.th32ProcessID == processId)
+            {
+                parentId = entry.th32ParentProcessID;
+                break;
+            }
+        }
+        while (Process32NextW(snapshot, &entry));
+    }
+
+    CloseHandle(snapshot);
+    return parentId;
+}
+
+static HANDLE OpenInheritedParentProcess()
+{
+    DWORD parentId = GetParentProcessId(GetCurrentProcessId());
+    if (parentId == 0)
+        return NULL;
+
+    return OpenProcess(PROCESS_CREATE_PROCESS, FALSE, parentId);
+}
 
 static bool wcsfindi(const wchar_t *str, const wchar_t *sub)
 {
@@ -123,19 +161,68 @@ int APIENTRY _BootstrapEntry(HWND, HINSTANCE, LPWSTR commandLine, int)
     LONG (NTAPI *NtRemoveProcessDebug)(HANDLE, HANDLE);
     LONG (NTAPI *NtClose)(HANDLE Handle);
 
-    STARTUPINFOW si;
+    STARTUPINFOEXW si;
     PROCESS_INFORMATION pi;
     ZeroMemory(&si, sizeof(si));
-    si.cb = sizeof(si);
+    si.StartupInfo.cb = sizeof(si);
+    ZeroMemory(&pi, sizeof(pi));
+
+    HANDLE parentProcess = OpenInheritedParentProcess();
+    SIZE_T attributeListSize = 0;
+    DWORD creationFlags = CREATE_SUSPENDED | DEBUG_ONLY_THIS_PROCESS;
+    bool attributeListInitialized = false;
+
+    if (parentProcess)
+    {
+        InitializeProcThreadAttributeList(NULL, 1, 0, &attributeListSize);
+        si.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(HeapAlloc(GetProcessHeap(), 0, attributeListSize));
+
+        if (si.lpAttributeList)
+            attributeListInitialized = InitializeProcThreadAttributeList(si.lpAttributeList, 1, 0, &attributeListSize);
+
+        if (attributeListInitialized
+            && UpdateProcThreadAttribute(si.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_PARENT_PROCESS,
+                &parentProcess, sizeof(parentProcess), NULL, NULL))
+        {
+            creationFlags |= EXTENDED_STARTUPINFO_PRESENT;
+        }
+        else
+        {
+            if (si.lpAttributeList)
+            {
+                if (attributeListInitialized)
+                    DeleteProcThreadAttributeList(si.lpAttributeList);
+                HeapFree(GetProcessHeap(), 0, si.lpAttributeList);
+                si.lpAttributeList = NULL;
+            }
+            CloseHandle(parentProcess);
+            parentProcess = NULL;
+        }
+    }
 
     if (!CreateProcessW(NULL, commandLine, NULL, NULL, FALSE,
-        CREATE_SUSPENDED | DEBUG_ONLY_THIS_PROCESS, NULL, NULL, &si, &pi))
+        creationFlags, NULL, NULL, &si.StartupInfo, &pi))
     {
         char msg[128];
         sprintf_s(msg, "Failed to create LeagueClientUx process, last error: 0x%08X.", GetLastError());
         MessageBoxA(NULL, msg, "Pengu Loader bootstrapper", MB_ICONWARNING | MB_OK | MB_TOPMOST);
+        if (si.lpAttributeList)
+        {
+            DeleteProcThreadAttributeList(si.lpAttributeList);
+            HeapFree(GetProcessHeap(), 0, si.lpAttributeList);
+        }
+        if (parentProcess)
+            CloseHandle(parentProcess);
         return 1;
     }
+
+    if (si.lpAttributeList)
+    {
+        DeleteProcThreadAttributeList(si.lpAttributeList);
+        HeapFree(GetProcessHeap(), 0, si.lpAttributeList);
+    }
+    if (parentProcess)
+        CloseHandle(parentProcess);
 
     HMODULE ntdll = GetModuleHandleA("ntdll");
     (LPVOID &)NtQueryInformationProcess = GetProcAddress(ntdll, "NtQueryInformationProcess");


### PR DESCRIPTION
## Summary

Fixes the Discord application-stream handoff from League Client to the in-game `League of Legends.exe` process when Pengu Loader is activated through IFEO/Universal mode.

In Universal mode, Windows starts Pengu through the IFEO `Debugger` value as `rundll32`, and Pengu then creates the real `LeagueClientUx.exe` process. That makes LCUX appear as a child of `rundll32` instead of Riot's normal launcher chain, which appears to break Discord's League Client -> game stream association.

This PR keeps the IFEO bootstrap behavior, but when `_BootstrapEntry` creates `LeagueClientUx.exe`, it uses `PROC_THREAD_ATTRIBUTE_PARENT_PROCESS` with the bootstrapper's inherited parent process. In local testing this made `LeagueClientUx.exe` appear under the normal Riot `LeagueClient.exe` process again instead of under `rundll32`.

## Validation

Locally validated on Windows with Discord application streaming:

- before this change, Discord stayed on the League Client stream when entering game
- hiding or closing the client caused Discord to pause/stop the stream instead of switching
- preserving Riot's original CEF window hierarchy did not fix the handoff
- with this parent-process change, Discord successfully transitioned from League Client to the game
- process diagnostics confirmed `LeagueClientUx.exe` was parented to `LeagueClient.exe` instead of `rundll32`
- Release x64 core build passes with MSBuild

## Notes

This is intentionally separate from the PluginFS PR. The local live test was also run with a combined PluginFS build so folder plugins could be validated at the same time, but the actual Discord fix is independent and only changes `core/src/dllmain.cc`.

This uses a documented Windows process creation attribute. It does not inject into the game process and does not change the game process. Reviewers should still treat this as a sensitive compatibility fix because anti-cheat/security tools can care about process ancestry.

Fixes #106.