### PR TITLE
Add stable and dev release channels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking-change
+    - title: Added
+      labels:
+        - enhancement
+        - feature
+    - title: Fixed
+      labels:
+        - bug
+        - fix
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build and release
 
 on:
   push:
@@ -11,11 +11,9 @@ on:
       - main
       - dev
   workflow_dispatch:
-    inputs:
-      release:
-        description: Build and sign a Windows release
-        type: boolean
-        default: false
+
+permissions:
+  contents: read
 
 jobs:
   windows:
@@ -32,9 +30,14 @@ jobs:
         run: |
           $commitHash = "${{ github.sha }}".Substring(0, 8)
           $appVersion = (Select-String -Path "loader\Program.cs" -Pattern 'VERSION = "(.+)"' -AllMatches).Matches.Groups[1].Value
+          $channel = switch ("${{ github.ref_name }}") {
+            "main" { "stable" }
+            "dev" { "dev" }
+            default { "ci" }
+          }
           "COMMIT_HASH=$commitHash" >> $env:GITHUB_ENV
           "APP_VERSION=$appVersion" >> $env:GITHUB_ENV
-          "ARTIFACT_NAME=pengu-v$appVersion-$commitHash-windows" >> $env:GITHUB_ENV
+          "BUILD_CHANNEL=$channel" >> $env:GITHUB_ENV
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
@@ -68,26 +71,46 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force bin
-          "${{ env.APP_VERSION }}+${{ env.COMMIT_HASH }}" >> bin/version
+          Set-Content bin/version "${{ env.APP_VERSION }}+${{ env.COMMIT_HASH }}+${{ env.BUILD_CHANNEL }}" -NoNewline
           msbuild pengu.sln /t:Restore,Build /m /p:Configuration=Release /p:Platform=x64
+
+      - name: Test update-channel logic
+        shell: pwsh
+        run: |
+          & ".\bin\Pengu Loader.exe" --self-test-updater
+          if ($LASTEXITCODE -ne 0) { throw "Updater self-test failed." }
 
       - name: Upload Windows build
         uses: actions/upload-artifact@v4
         id: windows-artifact
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          name: pengu-v${{ env.APP_VERSION }}-${{ env.COMMIT_HASH }}-${{ env.BUILD_CHANNEL }}-windows
           path: |
             bin/*.exe
             bin/*.dll
             bin/version
 
+      - name: Package dev release
+        if: ${{ github.event_name == 'push' && github.ref_name == 'dev' }}
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force dist
+          Compress-Archive -Path bin/*.exe,bin/*.dll,bin/version -DestinationPath dist/pengu-v${{ env.APP_VERSION }}-dev-windows.zip -Force
+
+      - name: Upload dev release files
+        if: ${{ github.event_name == 'push' && github.ref_name == 'dev' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows
+          path: dist/*
+
       - name: Remove unsigned output
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release }}
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         shell: pwsh
         run: Remove-Item bin/* -Recurse -Force
 
-      - name: Sign the build
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release }}
+      - name: Sign stable build
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         uses: signpath/github-action-submit-signing-request@v1
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -99,24 +122,25 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: bin
 
-      - name: Make installer and portable archive
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release }}
+      - name: Make stable installer and portable archive
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force bin-signed
-          Compress-Archive -Path bin/* -DestinationPath bin-signed/pengu-v${{ env.APP_VERSION }}-portable.zip -Force
-          & "$env:ProgramFiles (x86)\Inno Setup 6\iscc.exe" /O"bin" /F"pengu-v${{ env.APP_VERSION }}-setup" scripts\setup.iss
+          Set-Content bin/version "${{ env.APP_VERSION }}+${{ env.COMMIT_HASH }}+stable" -NoNewline
+          Compress-Archive -Path bin/* -DestinationPath bin-signed/pengu-v${{ env.APP_VERSION }}-stable-windows.zip -Force
+          & "$env:ProgramFiles (x86)\Inno Setup 6\iscc.exe" /O"bin" /F"pengu-v${{ env.APP_VERSION }}-stable-setup" scripts\setup.iss
 
-      - name: Upload installer for signing
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release }}
+      - name: Upload stable installer for signing
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         uses: actions/upload-artifact@v4
         id: installer-artifact
         with:
-          name: ${{ env.ARTIFACT_NAME }}-installer
+          name: stable-installer
           path: bin/pengu-*-setup.exe
 
-      - name: Sign the installer
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release }}
+      - name: Sign stable installer
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         uses: signpath/github-action-submit-signing-request@v1
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -128,12 +152,12 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: bin-signed
 
-      - name: Upload signed release
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release }}
+      - name: Upload stable release files
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}-signed
-          path: bin-signed/
+          name: release-windows
+          path: bin-signed/*
 
   macos:
     runs-on: macos-latest
@@ -150,8 +174,14 @@ jobs:
 
       - name: Prepare environment variables
         run: |
+          case "$GITHUB_REF_NAME" in
+            main) channel=stable ;;
+            dev) channel=dev ;;
+            *) channel=ci ;;
+          esac
           echo "COMMIT_HASH=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_ENV"
-          echo "APP_VERSION=$(node -p 'require("./plugins/package.json").version')" >> "$GITHUB_ENV"
+          echo "APP_VERSION=$(sed -n 's/.*VERSION = "\([^" ]*\)".*/\1/p' loader/Program.cs)" >> "$GITHUB_ENV"
+          echo "BUILD_CHANNEL=$channel" >> "$GITHUB_ENV"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -167,13 +197,75 @@ jobs:
       - name: Build macOS core
         run: |
           make release
-          echo "${{ env.APP_VERSION }}+${{ env.COMMIT_HASH }}" > bin/version
+          echo "${{ env.APP_VERSION }}+${{ env.COMMIT_HASH }}+${{ env.BUILD_CHANNEL }}" > bin/version
 
       - name: Upload macOS core
         uses: actions/upload-artifact@v4
         with:
-          name: pengu-v${{ env.APP_VERSION }}-${{ env.COMMIT_HASH }}-macos-core
+          name: pengu-v${{ env.APP_VERSION }}-${{ env.COMMIT_HASH }}-${{ env.BUILD_CHANNEL }}-macos-core
           path: |
             bin/core.dylib
             bin/insert_dylib
             bin/version
+
+      - name: Package macOS release
+        if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'dev') }}
+        run: |
+          mkdir dist
+          zip -j "dist/pengu-v${{ env.APP_VERSION }}-${{ env.BUILD_CHANNEL }}-macos-core.zip" bin/core.dylib bin/insert_dylib bin/version
+
+      - name: Upload macOS release files
+        if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'dev') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos
+          path: dist/*
+
+  release:
+    if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'dev') }}
+    needs:
+      - windows
+      - macos
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download release files
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(sed -n 's/.*VERSION = "\([^" ]*\)".*/\1/p' loader/Program.cs)
+          channel=$([ "$GITHUB_REF_NAME" = main ] && echo stable || echo dev)
+          tag="v${version}-${channel}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+
+          if [ "$channel" = stable ]; then
+            previous=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" --jq 'map(select(.draft == false and .prerelease == false))[0].tag_name // empty')
+            title="Pengu Loader v${version} Stable"
+            channel_flags=(--latest)
+          else
+            previous=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" --jq 'map(select(.draft == false and .prerelease == true))[0].tag_name // empty')
+            title="Pengu Loader v${version} Development"
+            channel_flags=(--prerelease --latest=false)
+          fi
+
+          notes_flags=(--generate-notes)
+          if [ -n "$previous" ]; then
+            notes_flags+=(--notes-start-tag "$previous")
+          fi
+
+          gh release create "$tag" dist/* \
+            --target "$GITHUB_SHA" \
+            --title "$title" \
+            "${notes_flags[@]}" \
+            "${channel_flags[@]}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Test update-channel logic
         shell: pwsh
         run: |
-          & ".\bin\Pengu Loader.exe" --self-test-updater
-          if ($LASTEXITCODE -ne 0) { throw "Updater self-test failed." }
+          $test = Start-Process ".\bin\Pengu Loader.exe" -ArgumentList "--self-test-updater" -Wait -PassThru
+          if ($test.ExitCode -ne 0) { throw "Updater self-test failed." }
 
       - name: Upload Windows build
         uses: actions/upload-artifact@v4

--- a/loader/Main/Config.cs
+++ b/loader/Main/Config.cs
@@ -86,6 +86,16 @@ namespace PenguLoader.Main
             set => SetBool("SuperLowSpecMode", value);
         }
 
+        public static string UpdateChannel
+        {
+            get => string.Equals(Get("UpdateChannel"), "dev", StringComparison.OrdinalIgnoreCase)
+                ? "dev"
+                : "stable";
+            set => Set("UpdateChannel", string.Equals(value, "dev", StringComparison.OrdinalIgnoreCase)
+                ? "dev"
+                : "stable");
+        }
+
         static string GetPath(string subpath)
         {
             return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, subpath);

--- a/loader/Main/Updater.cs
+++ b/loader/Main/Updater.cs
@@ -1,11 +1,13 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web.Script.Serialization;
 using System.Windows;
 using Ookii.Dialogs.Wpf;
 
@@ -13,17 +15,42 @@ namespace PenguLoader.Main
 {
     static class Updater
     {
-        static string ApiUrl => $"https://api.github.com/repos/{Program.GithubRepo}/releases/latest";
-        static string DownloadUrl => $"https://github.com/{Program.GithubRepo}/releases/latest";
+        static string StableApiUrl => $"https://api.github.com/repos/{Program.GithubRepo}/releases/latest";
+        static string ReleasesApiUrl => $"https://api.github.com/repos/{Program.GithubRepo}/releases?per_page=20";
+        static string ReleasesUrl => $"https://github.com/{Program.GithubRepo}/releases";
 
-        const string USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" +
-            " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36";
+        const string USER_AGENT = "PenguLoader-Updater/1.0";
+
+        static bool _checking;
 
         class Update
         {
             public string Version;
-            public string Changes;
             public string DownloadUrl;
+            public string ReleaseUrl;
+        }
+
+        class BuildInfo
+        {
+            public Version Version;
+            public string Commit;
+            public string Channel;
+        }
+
+        public class GitHubAsset
+        {
+            public string name { get; set; }
+            public string browser_download_url { get; set; }
+        }
+
+        public class GitHubRelease
+        {
+            public string tag_name { get; set; }
+            public string target_commitish { get; set; }
+            public string html_url { get; set; }
+            public bool draft { get; set; }
+            public bool prerelease { get; set; }
+            public GitHubAsset[] assets { get; set; }
         }
 
         static Updater()
@@ -33,8 +60,25 @@ namespace PenguLoader.Main
 
         public static async void CheckUpdate()
         {
+            if (_checking)
+                return;
+
+            _checking = true;
+            try
+            {
+                await CheckUpdateCore();
+            }
+            finally
+            {
+                _checking = false;
+            }
+        }
+
+        static async Task CheckUpdateCore()
+        {
             var update = await FetchUpdate();
-            if (update == null) return;
+            if (update == null)
+                return;
 
             var dialog = new ProgressDialog()
             {
@@ -104,7 +148,7 @@ namespace PenguLoader.Main
                     "Failed to download update. Please try downloading the update on GitHub releases page.",
                     Program.Name, MessageBoxButton.OK, MessageBoxImage.Warning);
 
-                Utils.OpenLink(DownloadUrl);
+                Utils.OpenLink(update.ReleaseUrl ?? ReleasesUrl);
             }
             finally
             {
@@ -116,40 +160,48 @@ namespace PenguLoader.Main
         {
             try
             {
-                var json = await DownloadString(ApiUrl);
-                var match = new Regex("\"tag_name\":\\s+\"(.*)\"").Match(json);
+                var channel = Config.UpdateChannel;
+                var serializer = new JavaScriptSerializer();
+                GitHubRelease release;
 
-                if (match.Success && match.Groups.Count > 1)
+                if (channel == "dev")
                 {
-                    var vtag = match.Groups[1].Value.ToLower();
-                    if (vtag.StartsWith("v"))
-                        vtag = vtag.Substring(1);
-
-                    var remote = new Version(vtag);
-                    var local = new Version(Program.VERSION);
-
-                    if (remote.CompareTo(local) > 0)
-                    {
-                        string changes = "";
-                        match = new Regex("\"body\":\\s+\"(.*)\"").Match(json);
-                        if (match.Success && match.Groups.Count > 1)
-                            changes = Regex.Unescape(match.Groups[1].Value);
-
-                        string downloadUrl = "";
-                        match = new Regex("\"browser_download_url\":\\s+\"(.*(\\d+\\.?)(?:-stable)?\\.zip)\"").Match(json);
-                        if (match.Success && match.Groups.Count > 1)
-                            downloadUrl = Regex.Unescape(match.Groups[1].Value);
-
-                        return new Update
-                        {
-                            Version = vtag,
-                            Changes = changes,
-                            DownloadUrl = downloadUrl
-                        };
-                    }
+                    var releases = serializer.Deserialize<GitHubRelease[]>(await DownloadString(ReleasesApiUrl));
+                    release = releases.FirstOrDefault(item => item.prerelease && !item.draft);
+                }
+                else
+                {
+                    release = serializer.Deserialize<GitHubRelease>(await DownloadString(StableApiUrl));
                 }
 
-                return null;
+                if (release == null || release.assets == null)
+                    return null;
+
+                var remoteVersion = ParseVersion(release.tag_name);
+                var local = ReadBuildInfo();
+                if (!ShouldUpdate(local, remoteVersion, release.target_commitish, channel))
+                    return null;
+
+                var suffix = "-" + channel + "-windows.zip";
+                var asset = release.assets.FirstOrDefault(item =>
+                    item.name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+
+                if (asset == null)
+                {
+                    asset = release.assets.FirstOrDefault(item =>
+                        item.name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)
+                        && item.name.IndexOf("macos", StringComparison.OrdinalIgnoreCase) < 0);
+                }
+
+                if (asset == null)
+                    throw new InvalidOperationException("The selected release has no Windows ZIP asset.");
+
+                return new Update
+                {
+                    Version = remoteVersion + " (" + (channel == "dev" ? "Dev" : "Stable") + ")",
+                    DownloadUrl = asset.browser_download_url,
+                    ReleaseUrl = release.html_url
+                };
             }
             catch (Exception ex)
             {
@@ -160,15 +212,89 @@ namespace PenguLoader.Main
             }
         }
 
+        static Version ParseVersion(string tag)
+        {
+            var match = Regex.Match(tag ?? "", @"\d+(?:\.\d+){1,3}");
+            Version version;
+            return match.Success && Version.TryParse(match.Value, out version)
+                ? version
+                : new Version(0, 0);
+        }
+
+        static BuildInfo ReadBuildInfo()
+        {
+            var value = Program.VERSION;
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "version");
+            if (File.Exists(path))
+                value = File.ReadAllText(path).Trim();
+
+            var parts = value.Split('+');
+            Version version;
+
+            return new BuildInfo
+            {
+                Version = Version.TryParse(parts[0], out version) ? version : new Version(0, 0),
+                Commit = parts.Length > 1 ? parts[1] : "",
+                Channel = parts.Length > 2 && parts[2] == "dev" ? "dev" : "stable"
+            };
+        }
+
+        static bool ShouldUpdate(BuildInfo local, Version remoteVersion, string remoteCommit, string channel)
+        {
+            if (local.Channel != channel)
+                return true;
+
+            if (IsCommit(remoteCommit))
+            {
+                if (SameCommit(local.Commit, remoteCommit))
+                    return false;
+
+                return remoteVersion.CompareTo(local.Version) >= 0;
+            }
+
+            return remoteVersion.CompareTo(local.Version) > 0;
+        }
+
+        static bool IsCommit(string value)
+        {
+            return Regex.IsMatch(value ?? "", "^[0-9a-fA-F]{7,40}$");
+        }
+
+        static bool SameCommit(string left, string right)
+        {
+            if (string.IsNullOrEmpty(left) || string.IsNullOrEmpty(right))
+                return false;
+
+            return left.StartsWith(right, StringComparison.OrdinalIgnoreCase)
+                || right.StartsWith(left, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool SelfTest()
+        {
+            var stable = new BuildInfo
+            {
+                Version = new Version(1, 2, 3),
+                Commit = "abcdef12",
+                Channel = "stable"
+            };
+
+            return ParseVersion("v1.2.3-dev.42") == new Version(1, 2, 3)
+                && !ShouldUpdate(stable, new Version(1, 2, 3), "abcdef1234567890", "stable")
+                && ShouldUpdate(stable, new Version(1, 2, 3), "1234567890abcdef", "stable")
+                && ShouldUpdate(stable, new Version(1, 1, 0), "1234567890abcdef", "dev");
+        }
+
         static async Task<string> DownloadString(string url)
         {
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
+            var request = (HttpWebRequest)WebRequest.Create(url);
             request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
             request.UserAgent = USER_AGENT;
+            request.Accept = "application/vnd.github+json";
+            request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
 
-            using (HttpWebResponse response = (HttpWebResponse)await request.GetResponseAsync())
-            using (Stream stream = response.GetResponseStream())
-            using (StreamReader reader = new StreamReader(stream))
+            using (var response = (HttpWebResponse)await request.GetResponseAsync())
+            using (var stream = response.GetResponseStream())
+            using (var reader = new StreamReader(stream))
             {
                 return await reader.ReadToEndAsync();
             }
@@ -176,7 +302,7 @@ namespace PenguLoader.Main
 
         static async Task DownloadFile(string url, string path, Action<long, long, int> onProgress)
         {
-            using (WebClient client = new WebClient())
+            using (var client = new WebClient())
             {
                 client.Headers.Add("User-Agent", USER_AGENT);
                 client.DownloadProgressChanged += (s, e) =>

--- a/loader/Program.cs
+++ b/loader/Program.cs
@@ -27,6 +27,9 @@ namespace PenguLoader
                 return 0;
             }
 
+            if (arg == "--self-test-updater")
+                return Updater.SelfTest() ? 0 : 1;
+
             using (var mutex = new Mutex(true, "989d2110-46da-4c8d-84c1-c4a42e43c424", out var createdNew))
             {
                 if (arg != null)

--- a/loader/Views/MainPage.xaml
+++ b/loader/Views/MainPage.xaml
@@ -73,6 +73,18 @@
                 <StackPanel VerticalAlignment="Center">
                     <CheckBox Content="{DynamicResource t_optimize_client}" IsChecked="{Binding Path=OptimizeClient, Mode=TwoWay}" Focusable="False" Margin="20,5" HorizontalAlignment="Stretch" />
                     <CheckBox Content="{DynamicResource t_super_potato_mode}" IsChecked="{Binding Path=SuperLowSpecMode, Mode=TwoWay}" Focusable="False" Margin="20,5" HorizontalAlignment="Stretch" />
+                    <Grid Margin="20,5">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Release channel" VerticalAlignment="Center" Margin="0,0,10,0" />
+                        <ComboBox
+                            Grid.Column="1"
+                            ItemsSource="{Binding UpdateChannels}"
+                            SelectedItem="{Binding UpdateChannel, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            HorizontalAlignment="Stretch" />
+                    </Grid>
                 </StackPanel>
             </StackPanel>
         </Grid>

--- a/loader/Views/MainPage.xaml.cs
+++ b/loader/Views/MainPage.xaml.cs
@@ -16,6 +16,23 @@ namespace PenguLoader.Views
 
         Window Owner => Window.GetWindow(this);
 
+        public string[] UpdateChannels { get; } = { "Stable (main)", "Development (dev)" };
+
+        public string UpdateChannel
+        {
+            get => Config.UpdateChannel == "dev" ? UpdateChannels[1] : UpdateChannels[0];
+            set
+            {
+                var channel = value == UpdateChannels[1] ? "dev" : "stable";
+                if (channel == Config.UpdateChannel)
+                    return;
+
+                Config.UpdateChannel = channel;
+                TriggerPropertyChanged(nameof(UpdateChannel));
+                Updater.CheckUpdate();
+            }
+        }
+
         public bool OptimizeClient
         {
             get => Config.OptimizeClient;

--- a/loader/loader.csproj
+++ b/loader/loader.csproj
@@ -54,6 +54,8 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xaml">


### PR DESCRIPTION
## What changes
- adds an in-app Stable (main) / Development (dev) release-channel selector
- lets users move in either direction, including returning from a newer dev build to stable
- publishes every dev push as a GitHub prerelease with Windows and macOS assets
- prepares main pushes to publish signed stable releases with Windows and macOS assets
- generates release notes from merged work
- preserves the SignPath sponsor acknowledgement

## Branch model
Feature work continues to branch from dev and merge back into dev. Only reviewed dev changes should later move into main. This PR does not touch main or PR #147.

## Validation
- .NET Release build passes locally
- updater channel self-test passes locally
- workflow YAML parses locally