### PR TITLE
Fix the first dev release notes baseline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,6 +255,9 @@ jobs:
             channel_flags=(--latest)
           else
             previous=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" --jq 'map(select(.draft == false and .prerelease == true))[0].tag_name // empty')
+            if [ -z "$previous" ]; then
+              previous=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')
+            fi
             title="Pengu Loader v${version} Development"
             channel_flags=(--prerelease --latest=false)
           fi


### PR DESCRIPTION
When no earlier prerelease exists, generate the first Dev release notes from the latest Stable tag instead of the repository's distant history. Later Dev releases continue comparing against the previous Dev prerelease.